### PR TITLE
feat: Align with the new credential schemes according to the 24.08 standard

### DIFF
--- a/docs/api/openAPI.json
+++ b/docs/api/openAPI.json
@@ -173,7 +173,8 @@
                     "grantAccess" : {
                       "scope" : "read",
                       "credentialTypes" : [
-                        "MembershipCredential"
+                        "MembershipCredential",
+                        "DataExchangeGovernanceCredential"
                       ],
                       "consumerDid" : "did:web:c464-203-129-213-107.ngrok-free.app:BPNL000000000000",
                       "providerDid" : "did:web:c464-203-129-213-107.ngrok-free.app:BPNL000000000000"
@@ -235,6 +236,20 @@
                   "value" : {
                     "scope" : [
                       "org.eclipse.tractusx.vc.type:MembershipCredential:read"
+                    ],
+                    "@context" : [
+                      "https://identity.foundation/presentation-exchange/submission/v1",
+                      "https://w3id.org/tractusx-trust/v0.8"
+                    ],
+                    "@type" : "PresentationQueryMessage"
+                  }
+                },
+                "Create VP access token for Membership Credential and DataExchange Governance Credential" : {
+                  "description" : "Create VP access token for Membership Credential and DataExchange Governance Credential",
+                  "value" : {
+                    "scope" : [
+                      "org.eclipse.tractusx.vc.type:MembershipCredential:read",
+                      "org.eclipse.tractusx.vc.type:DataExchangeGovernanceCredential:read"
                     ],
                     "@context" : [
                       "https://identity.foundation/presentation-exchange/submission/v1",

--- a/docs/architecture/main.md
+++ b/docs/architecture/main.md
@@ -83,7 +83,7 @@ interface or API documentation.
   minimum requirement to address is enabling the dependent microservices to deploy and pass the E2E tests. However, the
   business logic of multiple services outside of this scope might be too complex and error-prone for simulation. We have
   to define a minimum viable stub and continue delivering if there is any necessity or further requirement. Currently
-  only `type:MembershipCredential` and `type:BPNCredential` are supported.
+  only `type:MembershipCredential`, `type:BPNCredential` and `type:DataExchangeGovernanceCredential` are supported.
 
 * **Security:** Security features such as authentication, authorization, and data encryption must also be simulated with
   the stub service.
@@ -730,7 +730,7 @@ Response Body:
 ![query.png](./images/query.png)
 
 This API is responsible for creating Verifiable Presentations based on the scope and tokens being passed. For the scope
-of the stub service, only `type:MembershipCredential` and `type:BpnCredential` are supported.
+of the stub service, only `type:MembershipCredential`, `type:BpnCredential` and `type:DataExchangeGovernanceCredential` are supported.
 
 Request Body:
 

--- a/src/main/java/org/eclipse/tractusx/wallet/stub/apidoc/EDCStubApiDoc.java
+++ b/src/main/java/org/eclipse/tractusx/wallet/stub/apidoc/EDCStubApiDoc.java
@@ -65,7 +65,8 @@ public class EDCStubApiDoc {
                                     "scope": "read",
                                     "credentialTypes":
                                     [
-                                        "MembershipCredential"
+                                        "MembershipCredential",
+                                        "DataExchangeGovernanceCredential"
                                     ],
                                     "consumerDid": "did:web:c464-203-129-213-107.ngrok-free.app:BPNL000000000000",
                                     "providerDid": "did:web:c464-203-129-213-107.ngrok-free.app:BPNL000000000000"
@@ -129,7 +130,22 @@ public class EDCStubApiDoc {
                                  ],
                                  "@type": "PresentationQueryMessage"
                              }
-                            """, description = "Create VP access token for membership VC", name = "Create VP access token for membership VC")
+                            """, description = "Create VP access token for membership VC", name = "Create VP access token for membership VC"),
+                    @ExampleObject(value = """
+                            {
+                                 "scope":
+                                 [
+                                     "org.eclipse.tractusx.vc.type:MembershipCredential:read",
+                                     "org.eclipse.tractusx.vc.type:DataExchangeGovernanceCredential:read"
+                                 ],
+                                 "@context":
+                                 [
+                                     "https://identity.foundation/presentation-exchange/submission/v1",
+                                     "https://w3id.org/tractusx-trust/v0.8"
+                                 ],
+                                 "@type": "PresentationQueryMessage"
+                             }
+                            """, description = "Create VP access token for Membership Credential and DataExchange Governance Credential", name = "Create VP access token for Membership Credential and DataExchange Governance Credential")
 
             })
     })

--- a/src/main/java/org/eclipse/tractusx/wallet/stub/utils/StringPool.java
+++ b/src/main/java/org/eclipse/tractusx/wallet/stub/utils/StringPool.java
@@ -30,9 +30,15 @@ public class StringPool {
     public static final String TOKEN_TYPE_BEARER = "Bearer";
     public static final String TOKEN = "token";
     public static final String HOLDER_IDENTIFIER = "holderIdentifier";
+    public static final String MEMBER_OF = "memberOf";
+    public static final String CONTRACT_TEMPLATE = "contractTemplate";
+    public static final String CONTRACT_VERSION = "contractVersion";
+    public static final String GROUP = "group";
+    public static final String USE_CASE = "useCase";
     public static final String BASIC = "Basic";
     public static final String MEMBERSHIP_CREDENTIAL = "MembershipCredential";
     public static final String BPN_CREDENTIAL = "BpnCredential";
+    public static final String DATA_EXCHANGE_CREDENTIAL = "DataExchangeGovernanceCredential";
     public static final String STATUS_LIST_2021_CREDENTIAL = "StatusList2021Credential";
     public static final String ENCODED_LIST = "encodedList";
     public static final String VERIFIABLE_CREDENTIAL_CAMEL_CASE = "verifiableCredential";


### PR DESCRIPTION
## Description

The `api/presentations/query` endpoint will be updated to support the new credential schemes of **BpnCredential** and **MembershipCredential**
Support for the **DataExchangeGovernanceCredential** in the `api/presentations/query` endpoint
Testcase updated with `DataExchangeGovernanceCredential`

## Why

Align with the [24.08 standard](https://catenax-ev.github.io/docs/next/standards/CX-0050-FrameworkAgreementCredential).


## Issue Link

Refs: #13 #14


## Checklist
Please delete options that are not relevant.

- [X] I have followed the contributing guidelines

- [ ] I have performed IP checks for added or updated 3rd party libraries

- [ ] I have added copyright and license headers, footers (for .md files) or files (for images) //open source requirement

- [X] I have performed a self-review of my own code

- [X] I have successfully tested my changes locally

- [X] I have added tests and updated existing tests that prove my changes work

- [X] I have checked that new and existing tests pass locally with my changes

- [X] I have commented my code, particularly in hard-to-understand areas