### PR TITLE
fix(helm): docker image tag updated with default value

### DIFF
--- a/charts/ssi-dim-wallet-stub/values.yaml
+++ b/charts/ssi-dim-wallet-stub/values.yaml
@@ -42,11 +42,11 @@ wallet:
 
   image:
     # -- Image repository
-    repository: tractusx/managed-identity-wallet
+    repository: tractusx/ssi-dim-wallet-stub
     # -- PullPolicy
     pullPolicy: IfNotPresent
     # -- Image tag (empty one will use "appVersion" value from chart definition)
-    tag: ""
+    tag: "latest"
 
   resources:
     requests:


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of the changes introduced by this pull request. Explain the problem it 
solves or the feature it adds. -->

Default values are updated for the docker image and tag

## Why

<!-- Why are these changes necessary? What problem does it solve? -->
There were wrong values in default values.yaml, and due to this we are not able to deploy the helm chart

## Issue Link

Refs: [19](https://github.com/eclipse-tractusx/ssi-dim-wallet-stub/issues/19)


## Checklist
Please delete options that are not relevant.

- [x] I have followed the contributing guidelines

- [ ] I have performed IP checks for added or updated 3rd party libraries

- [ ] I have added copyright and license headers, footers (for .md files) or files (for images) //open source requirement

- [x] I have performed a self-review of my own code

- [ ] I have successfully tested my changes locally

- [ ] I have added tests and updated existing tests that prove my changes work

- [ ] I have checked that new and existing tests pass locally with my changes

- [ ] I have commented my code, particularly in hard-to-understand areas