### PR TITLE
fix: Helm charts ingress base template

### DIFF
--- a/charts/ssi-dim-wallet-stub/Chart.yaml
+++ b/charts/ssi-dim-wallet-stub/Chart.yaml
@@ -22,7 +22,7 @@ name: ssi-dim-wallet-stub
 description: |
   A Helm chart to deploy SSI DIM wallet stub in kubernetes cluster
 type: application
-version: 0.1.4
+version: 0.1.5
 appVersion: "0.0.4"
 home: https://github.com/eclipse-tractusx/ssi-dim-wallet-stub/tree/main/charts/ssi-dim-wallet-stub
 sources:

--- a/charts/ssi-dim-wallet-stub/templates/ingress.yaml
+++ b/charts/ssi-dim-wallet-stub/templates/ingress.yaml
@@ -28,11 +28,11 @@ metadata:
 {{ .Values.wallet.ingress.annotations | toYaml | indent 4 }}
 spec:
   ingressClassName: {{ .Values.wallet.ingress.className }}
-  {{- if .Values.wallet.ingress.tls }}
+  {{- if .Values.wallet.ingress.tls.enabled }}
   tls:
     - hosts:
         - {{ .Values.wallet.host }}
-      secretName: ssi-dim-wallet-stub-certificate-secret
+      secretName: {{- if .Values.wallet.ingress.tls.name }}
   {{- end }}
   rules:
     - host: {{ .Values.wallet.host }}

--- a/charts/ssi-dim-wallet-stub/values.yaml
+++ b/charts/ssi-dim-wallet-stub/values.yaml
@@ -35,9 +35,6 @@ wallet:
   # -- The service name
   serviceName: "ssi-dim-wallet-service"
 
-  # -- The secret name
-  secretName: "ssi-dim-wallet-secret"
-
   ingressName: "ssi-dim-wallet-ingress"
 
   image:
@@ -91,7 +88,10 @@ wallet:
   # -- ingress configuration
   ingress:
     enabled: false
-    tls: false
+    tls:
+      enabled: false
+      # -- Name of the tls secret
+      name: ""
     urlPrefix: /
     className: nginx
     annotations: {}

--- a/charts/ssi-dim-wallet-stub/values.yaml
+++ b/charts/ssi-dim-wallet-stub/values.yaml
@@ -31,7 +31,10 @@ wallet:
 
   # -- The configmap name
   configName: "ssi-dim-wallet-config"
-
+  
+  # -- The secret name
+  secretName: "ssi-dim-wallet-secret"
+  
   # -- The service name
   serviceName: "ssi-dim-wallet-service"
 


### PR DESCRIPTION
## Description

This PR fixes the helm charts ingress base template

## Why

The TLS secret name was hardcoded, with this PR now the secret name will be picked up from the values file