### PR TITLE
fix: bump chart version from `0.1.5` to `0.1.6`

### DIFF
--- a/charts/ssi-dim-wallet-stub/Chart.yaml
+++ b/charts/ssi-dim-wallet-stub/Chart.yaml
@@ -22,7 +22,7 @@ name: ssi-dim-wallet-stub
 description: |
   A Helm chart to deploy SSI DIM wallet stub in kubernetes cluster
 type: application
-version: 0.1.5
+version: 0.1.6
 appVersion: "0.0.4"
 home: https://github.com/eclipse-tractusx/ssi-dim-wallet-stub/tree/main/charts/ssi-dim-wallet-stub
 sources:


### PR DESCRIPTION
This PR bumps the helm chart version from ```0.1.5``` to ```0.1.6```