### PR TITLE
feat: added UsagePurposeCredential

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 All notable changes to this project will be documented in this file.
 
+## [0.0.6](https://github.com/eclipse-tractusx/ssi-dim-wallet-stub/compare/0.0.5...0.0.6) - 2025-05-15
+
+### Added
+
+* feat: added UsagePurposeCredential in https://github.com/eclipse-tractusx/ssi-dim-wallet-stub/pull/51 
+
 ## [0.0.3](https://github.com/eclipse-tractusx/ssi-dim-wallet-stub/compare/0.0.2...0.0.3) - 2024-11-20
 
 # Added

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -79,7 +79,7 @@ maven/mavencentral/org.apache.james/apache-mime4j-dom/0.8.9, Apache-2.0, approve
 maven/mavencentral/org.apache.james/apache-mime4j-storage/0.8.9, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.logging.log4j/log4j-api/2.23.1, Apache-2.0, approved, #13368
 maven/mavencentral/org.apache.logging.log4j/log4j-to-slf4j/2.23.1, Apache-2.0, approved, #15121
-maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-core/10.1.26, Apache-2.0 AND (EPL-2.0 OR (GPL-2.0 WITH Classpath-exception-2.0)) AND CDDL-1.0 AND (CDDL-1.1 OR (GPL-2.0-only WITH Classpath-exception-2.0)) AND EPL-2.0, approved, #15195
+maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-core/10.1.26, Apache-2.0 AND (EPL-2.0 OR (GPL-2.0-only WITH Classpath-exception-2.0)) AND CDDL-1.0 AND (CDDL-1.1 OR (GPL-2.0-only WITH Classpath-exception-2.0)) AND EPL-2.0, approved, #15195
 maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-el/10.1.26, Apache-2.0, approved, #6997
 maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-websocket/10.1.26, Apache-2.0, approved, #7920
 maven/mavencentral/org.apiguardian/apiguardian-api/1.1.2, Apache-2.0, approved, #17641

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -4,15 +4,32 @@ maven/mavencentral/com.apicatalog/carbon-did/0.3.0, Apache-2.0, approved, clearl
 maven/mavencentral/com.apicatalog/copper-multibase/0.5.0, Apache-2.0, approved, #14501
 maven/mavencentral/com.apicatalog/copper-multicodec/0.1.1, Apache-2.0, approved, #14500
 maven/mavencentral/com.apicatalog/iron-verifiable-credentials/0.14.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.apicatalog/titanium-json-ld/1.0.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.apicatalog/titanium-json-ld/1.4.0, Apache-2.0, approved, #15200
+maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.15.3, Apache-2.0, approved, #15260
+maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.16.0, Apache-2.0, approved, #11606
+maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.16.2, Apache-2.0, approved, #11606
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.17.2, Apache-2.0, approved, #13672
+maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.15.3, Apache-2.0 AND MIT AND BSD-2-Clause, approved, #15194
 maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.17.2, Apache-2.0 AND MIT, approved, #13665
+maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.11.0, Apache-2.0, approved, CQ23093
+maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.15.3, Apache-2.0, approved, #15199
+maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.16.0, Apache-2.0, approved, #11605
+maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.16.2, Apache-2.0, approved, #11605
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.17.2, Apache-2.0, approved, #13671
+maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.16.0, Apache-2.0, approved, #11855
+maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.16.2, Apache-2.0, approved, #11855
 maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.17.2, Apache-2.0, approved, #13669
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.17.2, Apache-2.0, approved, #15117
+maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.16.0, Apache-2.0, approved, #11853
+maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.16.2, Apache-2.0, approved, #11853
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.17.2, Apache-2.0, approved, #14160
+maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-base/2.15.3, Apache-2.0, approved, #9235
 maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-base/2.17.2, Apache-2.0, approved, #14194
+maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.15.3, Apache-2.0, approved, #9236
+maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.16.2, Apache-2.0, approved, #11858
 maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.17.2, Apache-2.0, approved, #14195
+maven/mavencentral/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.15.3, Apache-2.0, approved, #9241
 maven/mavencentral/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.17.2, Apache-2.0, approved, #13668
 maven/mavencentral/com.fasterxml.jackson.module/jackson-module-parameter-names/2.17.2, Apache-2.0, approved, #15122
 maven/mavencentral/com.fasterxml.jackson/jackson-bom/2.17.2, Apache-2.0, approved, #14162
@@ -31,7 +48,7 @@ maven/mavencentral/com.sun.istack/istack-commons-tools/4.1.2, BSD-3-Clause, appr
 maven/mavencentral/com.sun.xml.bind.external/relaxng-datatype/4.0.3, BSD-3-Clause, approved, ee4j.jaxb-impl
 maven/mavencentral/com.sun.xml.bind.external/rngom/4.0.3, BSD-3-Clause, approved, ee4j.jaxb-impl
 maven/mavencentral/com.vaadin.external.google/android-json/0.0.20131108.vaadin1, Apache-2.0, approved, CQ21310
-maven/mavencentral/commons-codec/commons-codec/1.16.1, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #9157
+maven/mavencentral/commons-codec/commons-codec/1.15, Apache-2.0 AND BSD-3-Clause AND LicenseRef-Public-Domain, approved, CQ22641
 maven/mavencentral/commons-fileupload/commons-fileupload/1.5, Apache-2.0, approved, #7109
 maven/mavencentral/commons-io/commons-io/2.11.0, Apache-2.0, approved, CQ23745
 maven/mavencentral/commons-logging/commons-logging/1.2, Apache-2.0, approved, CQ10162
@@ -44,8 +61,9 @@ maven/mavencentral/io.github.openfeign/feign-slf4j/13.3, Apache-2.0, approved, c
 maven/mavencentral/io.micrometer/micrometer-commons/1.13.2, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #14826
 maven/mavencentral/io.micrometer/micrometer-core/1.13.2, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #14827
 maven/mavencentral/io.micrometer/micrometer-jakarta9/1.13.2, Apache-2.0, approved, clearlydefined
+maven/mavencentral/io.micrometer/micrometer-observation/1.12.8, Apache-2.0, approved, #11680
 maven/mavencentral/io.micrometer/micrometer-observation/1.13.2, Apache-2.0, approved, #14829
-maven/mavencentral/io.opentelemetry/opentelemetry-api/1.37.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/io.opentelemetry/opentelemetry-api/1.32.0, Apache-2.0, approved, #11682
 maven/mavencentral/io.opentelemetry/opentelemetry-context/1.37.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.setl/rdf-urdna/1.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.swagger.core.v3/swagger-annotations-jakarta/2.2.20, Apache-2.0, approved, #5947
@@ -53,24 +71,33 @@ maven/mavencentral/io.swagger.core.v3/swagger-annotations-jakarta/2.2.22, Apache
 maven/mavencentral/io.swagger.core.v3/swagger-core-jakarta/2.2.20, Apache-2.0, approved, #5929
 maven/mavencentral/io.swagger.core.v3/swagger-core-jakarta/2.2.22, Apache-2.0, approved, #5929
 maven/mavencentral/io.swagger.core.v3/swagger-integration-jakarta/2.2.22, Apache-2.0, approved, #11475
+maven/mavencentral/io.swagger.core.v3/swagger-jaxrs2-jakarta/2.2.21, Apache-2.0, approved, #11477
 maven/mavencentral/io.swagger.core.v3/swagger-jaxrs2-jakarta/2.2.22, Apache-2.0, approved, #11477
 maven/mavencentral/io.swagger.core.v3/swagger-models-jakarta/2.2.20, Apache-2.0, approved, #5919
 maven/mavencentral/io.swagger.core.v3/swagger-models-jakarta/2.2.22, Apache-2.0, approved, #5919
+maven/mavencentral/jakarta.activation/jakarta.activation-api/2.1.0, EPL-2.0 OR BSD-3-Clause OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jaf
+maven/mavencentral/jakarta.activation/jakarta.activation-api/2.1.2, EPL-2.0 OR BSD-3-Clause OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jaf
 maven/mavencentral/jakarta.activation/jakarta.activation-api/2.1.3, EPL-2.0 OR BSD-3-Clause OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jaf
 maven/mavencentral/jakarta.annotation/jakarta.annotation-api/2.1.1, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.ca
 maven/mavencentral/jakarta.json/jakarta.json-api/2.1.3, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jsonp
-maven/mavencentral/jakarta.mail/jakarta.mail-api/2.1.3, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.mail
+maven/mavencentral/jakarta.mail/jakarta.mail-api/2.1.2, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.mail
 maven/mavencentral/jakarta.validation/jakarta.validation-api/3.0.2, Apache-2.0, approved, ee4j.validation
 maven/mavencentral/jakarta.ws.rs/jakarta.ws.rs-api/3.1.0, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.rest
+maven/mavencentral/jakarta.ws.rs/jakarta.ws.rs-api/4.0.0, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.rest
+maven/mavencentral/jakarta.xml.bind/jakarta.xml.bind-api/3.0.1, BSD-3-Clause, approved, ee4j.jaxb
 maven/mavencentral/jakarta.xml.bind/jakarta.xml.bind-api/4.0.2, BSD-3-Clause, approved, ee4j.jaxb
-maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.14.18, Apache-2.0, approved, #7164
-maven/mavencentral/net.bytebuddy/byte-buddy/1.14.18, Apache-2.0 AND BSD-3-Clause, approved, #7163
+maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.14.12, Apache-2.0, approved, #7164
+maven/mavencentral/net.bytebuddy/byte-buddy/1.14.11, Apache-2.0 AND BSD-3-Clause, approved, #7163
+maven/mavencentral/net.bytebuddy/byte-buddy/1.14.12, Apache-2.0 AND BSD-3-Clause, approved, #7163
 maven/mavencentral/net.minidev/accessors-smart/2.5.1, Apache-2.0, approved, #19432
+maven/mavencentral/net.minidev/json-smart/2.5.0, Apache-2.0, approved, #19431
 maven/mavencentral/net.minidev/json-smart/2.5.1, Apache-2.0, approved, #19431
+maven/mavencentral/org.apache.commons/commons-lang3/3.14.0, Apache-2.0, approved, #11677
 maven/mavencentral/org.apache.commons/commons-lang3/3.15.0, Apache-2.0, approved, #19689
 maven/mavencentral/org.apache.commons/commons-text/1.12.0, Apache-2.0, approved, #14414
 maven/mavencentral/org.apache.httpcomponents.client5/httpclient5/5.3.1, Apache-2.0, approved, #12911
-maven/mavencentral/org.apache.httpcomponents.core5/httpcore5-h2/5.2.5, Apache-2.0, approved, #10658
+maven/mavencentral/org.apache.httpcomponents.core5/httpcore5-h2/5.2.4, Apache-2.0, approved, #10658
+maven/mavencentral/org.apache.httpcomponents.core5/httpcore5/5.2.4, Apache-2.0, approved, #9652
 maven/mavencentral/org.apache.httpcomponents.core5/httpcore5/5.2.5, Apache-2.0, approved, #9652
 maven/mavencentral/org.apache.httpcomponents/httpclient/4.5.14, Apache-2.0, approved, #15248
 maven/mavencentral/org.apache.httpcomponents/httpcore/4.4.16, Apache-2.0, approved, CQ23528
@@ -87,8 +114,8 @@ maven/mavencentral/org.assertj/assertj-core/3.25.3, Apache-2.0, approved, #12585
 maven/mavencentral/org.awaitility/awaitility/4.2.1, Apache-2.0, approved, #14178
 maven/mavencentral/org.bouncycastle/bcprov-jdk18on/1.78, MIT AND CC0-1.0, approved, #14433
 maven/mavencentral/org.bouncycastle/bcprov-jdk18on/1.78.1, MIT AND CC0-1.0, approved, #14433
-maven/mavencentral/org.eclipse.angus/angus-activation/2.0.2, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.angus
-maven/mavencentral/org.eclipse.angus/angus-mail/2.0.3, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.angus
+maven/mavencentral/org.eclipse.angus/angus-activation/1.0.0, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.angus
+maven/mavencentral/org.eclipse.angus/angus-mail/1.0.0, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.angus
 maven/mavencentral/org.eclipse.edc/api-configuration/0.8.1, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/boot-spi/0.8.1, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/core-spi/0.8.1, Apache-2.0, approved, technology.edc
@@ -119,14 +146,15 @@ maven/mavencentral/org.eclipse.edc/verifiable-credentials-spi/0.8.1, Apache-2.0,
 maven/mavencentral/org.eclipse.edc/web-spi/0.8.1, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.jetty.toolchain/jetty-jakarta-servlet-api/5.0.2, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.eclipse.parsson/parsson/1.1.6, EPL-2.0, approved, ee4j.parsson
-maven/mavencentral/org.glassfish.jaxb/codemodel/4.0.5, BSD-3-Clause, approved, ee4j.jaxb-impl
-maven/mavencentral/org.glassfish.jaxb/jaxb-core/4.0.5, BSD-3-Clause, approved, ee4j.jaxb-impl
-maven/mavencentral/org.glassfish.jaxb/jaxb-jxc/4.0.5, BSD-3-Clause, approved, ee4j.jaxb-impl
-maven/mavencentral/org.glassfish.jaxb/jaxb-runtime/4.0.5, BSD-3-Clause, approved, ee4j.jaxb-impl
-maven/mavencentral/org.glassfish.jaxb/jaxb-xjc/4.0.5, BSD-3-Clause, approved, ee4j.jaxb-impl
-maven/mavencentral/org.glassfish.jaxb/txw2/4.0.5, BSD-3-Clause, approved, ee4j.jaxb-impl
-maven/mavencentral/org.glassfish.jaxb/xsom/4.0.5, BSD-3-Clause, approved, ee4j.jaxb-impl
+maven/mavencentral/org.glassfish.jaxb/codemodel/4.0.3, BSD-3-Clause, approved, ee4j.jaxb-impl
+maven/mavencentral/org.glassfish.jaxb/jaxb-core/4.0.3, BSD-3-Clause, approved, ee4j.jaxb-impl
+maven/mavencentral/org.glassfish.jaxb/jaxb-jxc/4.0.3, BSD-3-Clause, approved, ee4j.jaxb-impl
+maven/mavencentral/org.glassfish.jaxb/jaxb-runtime/4.0.3, BSD-3-Clause, approved, ee4j.jaxb-impl
+maven/mavencentral/org.glassfish.jaxb/jaxb-xjc/4.0.3, BSD-3-Clause, approved, ee4j.jaxb-impl
+maven/mavencentral/org.glassfish.jaxb/txw2/4.0.3, BSD-3-Clause, approved, ee4j.jaxb-impl
+maven/mavencentral/org.glassfish.jaxb/xsom/4.0.3, BSD-3-Clause, approved, ee4j.jaxb-impl
 maven/mavencentral/org.glassfish/jakarta.json/2.0.1, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jsonp
+maven/mavencentral/org.hamcrest/hamcrest/2.1, BSD-3-Clause, approved, clearlydefined
 maven/mavencentral/org.hamcrest/hamcrest/2.2, BSD-3-Clause, approved, #17677
 maven/mavencentral/org.hdrhistogram/HdrHistogram/2.2.2, BSD-2-Clause AND CC0-1.0 AND CC0-1.0, approved, #14828
 maven/mavencentral/org.jacoco/org.jacoco.agent/0.8.11, EPL-2.0, approved, CQ23285
@@ -144,6 +172,7 @@ maven/mavencentral/org.jboss.resteasy/resteasy-jaxb-provider/6.2.7.Final, Apache
 maven/mavencentral/org.jboss.resteasy/resteasy-multipart-provider/6.2.7.Final, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.jboss/jandex/2.4.4.Final, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.jetbrains/annotations/24.1.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.junit.jupiter/junit-jupiter-api/5.10.2, EPL-2.0, approved, #9714
 maven/mavencentral/org.junit.jupiter/junit-jupiter-api/5.10.3, EPL-2.0, approved, #9714
 maven/mavencentral/org.junit.jupiter/junit-jupiter-engine/5.10.3, EPL-2.0, approved, #9711
 maven/mavencentral/org.junit.jupiter/junit-jupiter-params/5.10.3, EPL-2.0, approved, #15250
@@ -163,24 +192,26 @@ maven/mavencentral/org.opentest4j/opentest4j/1.3.0, Apache-2.0, approved, #9713
 maven/mavencentral/org.ow2.asm/asm-commons/9.6, BSD-3-Clause, approved, #10775
 maven/mavencentral/org.ow2.asm/asm-tree/9.6, BSD-3-Clause, approved, #10773
 maven/mavencentral/org.ow2.asm/asm/9.6, BSD-3-Clause, approved, #10776
-maven/mavencentral/org.projectlombok/lombok/1.18.34, MIT, approved, #15192
 maven/mavencentral/org.reactivestreams/reactive-streams/1.0.4, CC0-1.0, approved, CQ16332
 maven/mavencentral/org.skyscreamer/jsonassert/1.5.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.slf4j/jul-to-slf4j/2.0.13, MIT, approved, #7698
+maven/mavencentral/org.slf4j/slf4j-api/1.7.26, MIT, approved, CQ13368
+maven/mavencentral/org.slf4j/slf4j-api/1.7.36, MIT, approved, CQ13368
+maven/mavencentral/org.slf4j/slf4j-api/2.0.11, MIT, approved, #5915
 maven/mavencentral/org.slf4j/slf4j-api/2.0.13, MIT, approved, #5915
+maven/mavencentral/org.slf4j/slf4j-api/2.0.9, MIT, approved, #5915
 maven/mavencentral/org.springdoc/springdoc-openapi-starter-common/2.4.0, Apache-2.0, approved, #13755
 maven/mavencentral/org.springdoc/springdoc-openapi-starter-webmvc-api/2.4.0, Apache-2.0, approved, #13748
 maven/mavencentral/org.springdoc/springdoc-openapi-starter-webmvc-ui/2.4.0, Apache-2.0, approved, #13754
 maven/mavencentral/org.springframework.boot/spring-boot-actuator-autoconfigure/3.3.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.springframework.boot/spring-boot-actuator/3.3.2, Apache-2.0, approved, #16976
+maven/mavencentral/org.springframework.boot/spring-boot-autoconfigure/3.2.3, Apache-2.0, approved, #11751
+maven/mavencentral/org.springframework.boot/spring-boot-autoconfigure/3.2.7, Apache-2.0, approved, #11751
 maven/mavencentral/org.springframework.boot/spring-boot-autoconfigure/3.3.2, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.springframework.boot/spring-boot-devtools/3.3.2, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.springframework.boot/spring-boot-starter-actuator/3.3.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.springframework.boot/spring-boot-starter-json/3.3.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.springframework.boot/spring-boot-starter-logging/3.3.2, Apache-2.0, approved, #16886
-maven/mavencentral/org.springframework.boot/spring-boot-starter-test/3.3.2, Apache-2.0, approved, #16975
 maven/mavencentral/org.springframework.boot/spring-boot-starter-tomcat/3.3.2, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.springframework.boot/spring-boot-starter-web/3.3.2, Apache-2.0, approved, #16893
+maven/mavencentral/org.springframework.boot/spring-boot-starter/3.2.7, Apache-2.0, approved, #11935
 maven/mavencentral/org.springframework.boot/spring-boot-starter/3.3.2, Apache-2.0, approved, #16895
 maven/mavencentral/org.springframework.boot/spring-boot-test-autoconfigure/3.3.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.springframework.boot/spring-boot-test/3.3.2, Apache-2.0, approved, clearlydefined
@@ -190,7 +221,7 @@ maven/mavencentral/org.springframework.cloud/spring-cloud-context/4.1.4, Apache-
 maven/mavencentral/org.springframework.cloud/spring-cloud-openfeign-core/4.1.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.springframework.cloud/spring-cloud-starter-openfeign/4.1.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.springframework.cloud/spring-cloud-starter/4.1.4, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.springframework.security/spring-security-crypto/6.3.1, Apache-2.0 AND ISC, approved, #20893
+maven/mavencentral/org.springframework.security/spring-security-crypto/6.2.5, Apache-2.0 AND ISC, approved, #11908
 maven/mavencentral/org.springframework.security/spring-security-rsa/1.1.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.springframework/spring-aop/6.1.11, Apache-2.0, approved, #15221
 maven/mavencentral/org.springframework/spring-beans/6.1.11, Apache-2.0, approved, #15213
@@ -199,8 +230,11 @@ maven/mavencentral/org.springframework/spring-core/6.1.11, Apache-2.0 AND BSD-3-
 maven/mavencentral/org.springframework/spring-expression/6.1.11, Apache-2.0, approved, #15264
 maven/mavencentral/org.springframework/spring-jcl/6.1.11, Apache-2.0, approved, #15266
 maven/mavencentral/org.springframework/spring-test/6.1.11, Apache-2.0, approved, #15265
+maven/mavencentral/org.springframework/spring-web/5.1.5.RELEASE, Apache-2.0 AND LicenseRef-Public-Domain, approved, CQ18367
+maven/mavencentral/org.springframework/spring-web/6.1.10, Apache-2.0, approved, #15188
 maven/mavencentral/org.springframework/spring-web/6.1.11, Apache-2.0, approved, #15188
 maven/mavencentral/org.springframework/spring-webmvc/6.1.11, Apache-2.0, approved, #15182
+maven/mavencentral/org.springframework/spring-webmvc/6.1.4, Apache-2.0, approved, #15182
 maven/mavencentral/org.webjars/swagger-ui/5.11.8, Apache-2.0, approved, #13756
 maven/mavencentral/org.xmlunit/xmlunit-core/2.9.1, Apache-2.0, approved, #6272
 maven/mavencentral/org.yaml/snakeyaml/2.2, Apache-2.0 AND (Apache-2.0 OR BSD-3-Clause OR EPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later), approved, #10232

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -4,32 +4,15 @@ maven/mavencentral/com.apicatalog/carbon-did/0.3.0, Apache-2.0, approved, clearl
 maven/mavencentral/com.apicatalog/copper-multibase/0.5.0, Apache-2.0, approved, #14501
 maven/mavencentral/com.apicatalog/copper-multicodec/0.1.1, Apache-2.0, approved, #14500
 maven/mavencentral/com.apicatalog/iron-verifiable-credentials/0.14.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.apicatalog/titanium-json-ld/1.0.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.apicatalog/titanium-json-ld/1.4.0, Apache-2.0, approved, #15200
-maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.15.3, Apache-2.0, approved, #15260
-maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.16.0, Apache-2.0, approved, #11606
-maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.16.2, Apache-2.0, approved, #11606
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.17.2, Apache-2.0, approved, #13672
-maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.15.3, , approved, #15194
 maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.17.2, Apache-2.0 AND MIT, approved, #13665
-maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.11.0, Apache-2.0, approved, CQ23093
-maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.15.3, Apache-2.0, approved, #15199
-maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.16.0, Apache-2.0, approved, #11605
-maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.16.2, Apache-2.0, approved, #11605
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.17.2, Apache-2.0, approved, #13671
-maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.16.0, Apache-2.0, approved, #11855
-maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.16.2, Apache-2.0, approved, #11855
 maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.17.2, Apache-2.0, approved, #13669
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.17.2, Apache-2.0, approved, #15117
-maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.16.0, Apache-2.0, approved, #11853
-maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.16.2, Apache-2.0, approved, #11853
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.17.2, Apache-2.0, approved, #14160
-maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-base/2.15.3, Apache-2.0, approved, #9235
 maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-base/2.17.2, Apache-2.0, approved, #14194
-maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.15.3, Apache-2.0, approved, #9236
-maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.16.2, Apache-2.0, approved, #11858
 maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.17.2, Apache-2.0, approved, #14195
-maven/mavencentral/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.15.3, Apache-2.0, approved, #9241
 maven/mavencentral/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.17.2, Apache-2.0, approved, #13668
 maven/mavencentral/com.fasterxml.jackson.module/jackson-module-parameter-names/2.17.2, Apache-2.0, approved, #15122
 maven/mavencentral/com.fasterxml.jackson/jackson-bom/2.17.2, Apache-2.0, approved, #14162
@@ -39,16 +22,16 @@ maven/mavencentral/com.google.code.findbugs/jsr305/3.0.2, Apache-2.0 and CC-BY-2
 maven/mavencentral/com.google.code.gson/gson/2.10.1, Apache-2.0, approved, #6159
 maven/mavencentral/com.google.crypto.tink/tink/1.13.0, Apache-2.0, approved, #14502
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.22.0, Apache-2.0, approved, #10661
-maven/mavencentral/com.google.protobuf/protobuf-java/3.25.1, BSD-3-Clause, approved, clearlydefined
+maven/mavencentral/com.google.protobuf/protobuf-java/3.25.1, BSD-3-Clause, approved, #19751
 maven/mavencentral/com.ibm.async/asyncutil/0.1.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.jayway.jsonpath/json-path/2.9.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.jayway.jsonpath/json-path/2.9.0, Apache-2.0, approved, #20009
 maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.40, Apache-2.0, approved, #15156
 maven/mavencentral/com.sun.istack/istack-commons-runtime/4.1.2, BSD-3-Clause, approved, #15290
 maven/mavencentral/com.sun.istack/istack-commons-tools/4.1.2, BSD-3-Clause, approved, #2580
 maven/mavencentral/com.sun.xml.bind.external/relaxng-datatype/4.0.3, BSD-3-Clause, approved, ee4j.jaxb-impl
 maven/mavencentral/com.sun.xml.bind.external/rngom/4.0.3, BSD-3-Clause, approved, ee4j.jaxb-impl
 maven/mavencentral/com.vaadin.external.google/android-json/0.0.20131108.vaadin1, Apache-2.0, approved, CQ21310
-maven/mavencentral/commons-codec/commons-codec/1.15, Apache-2.0 AND BSD-3-Clause AND LicenseRef-Public-Domain, approved, CQ22641
+maven/mavencentral/commons-codec/commons-codec/1.16.1, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #9157
 maven/mavencentral/commons-fileupload/commons-fileupload/1.5, Apache-2.0, approved, #7109
 maven/mavencentral/commons-io/commons-io/2.11.0, Apache-2.0, approved, CQ23745
 maven/mavencentral/commons-logging/commons-logging/1.2, Apache-2.0, approved, CQ10162
@@ -61,9 +44,8 @@ maven/mavencentral/io.github.openfeign/feign-slf4j/13.3, Apache-2.0, approved, c
 maven/mavencentral/io.micrometer/micrometer-commons/1.13.2, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #14826
 maven/mavencentral/io.micrometer/micrometer-core/1.13.2, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #14827
 maven/mavencentral/io.micrometer/micrometer-jakarta9/1.13.2, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.micrometer/micrometer-observation/1.12.8, Apache-2.0, approved, #11680
 maven/mavencentral/io.micrometer/micrometer-observation/1.13.2, Apache-2.0, approved, #14829
-maven/mavencentral/io.opentelemetry/opentelemetry-api/1.32.0, Apache-2.0, approved, #11682
+maven/mavencentral/io.opentelemetry/opentelemetry-api/1.37.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.opentelemetry/opentelemetry-context/1.37.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.setl/rdf-urdna/1.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.swagger.core.v3/swagger-annotations-jakarta/2.2.20, Apache-2.0, approved, #5947
@@ -71,33 +53,24 @@ maven/mavencentral/io.swagger.core.v3/swagger-annotations-jakarta/2.2.22, Apache
 maven/mavencentral/io.swagger.core.v3/swagger-core-jakarta/2.2.20, Apache-2.0, approved, #5929
 maven/mavencentral/io.swagger.core.v3/swagger-core-jakarta/2.2.22, Apache-2.0, approved, #5929
 maven/mavencentral/io.swagger.core.v3/swagger-integration-jakarta/2.2.22, Apache-2.0, approved, #11475
-maven/mavencentral/io.swagger.core.v3/swagger-jaxrs2-jakarta/2.2.21, Apache-2.0, approved, #11477
 maven/mavencentral/io.swagger.core.v3/swagger-jaxrs2-jakarta/2.2.22, Apache-2.0, approved, #11477
 maven/mavencentral/io.swagger.core.v3/swagger-models-jakarta/2.2.20, Apache-2.0, approved, #5919
 maven/mavencentral/io.swagger.core.v3/swagger-models-jakarta/2.2.22, Apache-2.0, approved, #5919
-maven/mavencentral/jakarta.activation/jakarta.activation-api/2.1.0, EPL-2.0 OR BSD-3-Clause OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jaf
-maven/mavencentral/jakarta.activation/jakarta.activation-api/2.1.2, EPL-2.0 OR BSD-3-Clause OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jaf
 maven/mavencentral/jakarta.activation/jakarta.activation-api/2.1.3, EPL-2.0 OR BSD-3-Clause OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jaf
 maven/mavencentral/jakarta.annotation/jakarta.annotation-api/2.1.1, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.ca
 maven/mavencentral/jakarta.json/jakarta.json-api/2.1.3, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jsonp
-maven/mavencentral/jakarta.mail/jakarta.mail-api/2.1.2, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.mail
+maven/mavencentral/jakarta.mail/jakarta.mail-api/2.1.3, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.mail
 maven/mavencentral/jakarta.validation/jakarta.validation-api/3.0.2, Apache-2.0, approved, ee4j.validation
 maven/mavencentral/jakarta.ws.rs/jakarta.ws.rs-api/3.1.0, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.rest
-maven/mavencentral/jakarta.ws.rs/jakarta.ws.rs-api/4.0.0, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.rest
-maven/mavencentral/jakarta.xml.bind/jakarta.xml.bind-api/3.0.1, BSD-3-Clause, approved, ee4j.jaxb
 maven/mavencentral/jakarta.xml.bind/jakarta.xml.bind-api/4.0.2, BSD-3-Clause, approved, ee4j.jaxb
-maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.14.12, Apache-2.0, approved, #7164
-maven/mavencentral/net.bytebuddy/byte-buddy/1.14.11, Apache-2.0 AND BSD-3-Clause, approved, #7163
-maven/mavencentral/net.bytebuddy/byte-buddy/1.14.12, Apache-2.0 AND BSD-3-Clause, approved, #7163
-maven/mavencentral/net.minidev/accessors-smart/2.5.1, Apache-2.0, approved, clearlydefined
-maven/mavencentral/net.minidev/json-smart/2.5.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/net.minidev/json-smart/2.5.1, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.apache.commons/commons-lang3/3.14.0, Apache-2.0, approved, #11677
-maven/mavencentral/org.apache.commons/commons-lang3/3.15.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.14.18, Apache-2.0, approved, #7164
+maven/mavencentral/net.bytebuddy/byte-buddy/1.14.18, Apache-2.0 AND BSD-3-Clause, approved, #7163
+maven/mavencentral/net.minidev/accessors-smart/2.5.1, Apache-2.0, approved, #19432
+maven/mavencentral/net.minidev/json-smart/2.5.1, Apache-2.0, approved, #19431
+maven/mavencentral/org.apache.commons/commons-lang3/3.15.0, Apache-2.0, approved, #19689
 maven/mavencentral/org.apache.commons/commons-text/1.12.0, Apache-2.0, approved, #14414
 maven/mavencentral/org.apache.httpcomponents.client5/httpclient5/5.3.1, Apache-2.0, approved, #12911
-maven/mavencentral/org.apache.httpcomponents.core5/httpcore5-h2/5.2.4, Apache-2.0, approved, #10658
-maven/mavencentral/org.apache.httpcomponents.core5/httpcore5/5.2.4, Apache-2.0, approved, #9652
+maven/mavencentral/org.apache.httpcomponents.core5/httpcore5-h2/5.2.5, Apache-2.0, approved, #10658
 maven/mavencentral/org.apache.httpcomponents.core5/httpcore5/5.2.5, Apache-2.0, approved, #9652
 maven/mavencentral/org.apache.httpcomponents/httpclient/4.5.14, Apache-2.0, approved, #15248
 maven/mavencentral/org.apache.httpcomponents/httpcore/4.4.16, Apache-2.0, approved, CQ23528
@@ -114,8 +87,8 @@ maven/mavencentral/org.assertj/assertj-core/3.25.3, Apache-2.0, approved, #12585
 maven/mavencentral/org.awaitility/awaitility/4.2.1, Apache-2.0, approved, #14178
 maven/mavencentral/org.bouncycastle/bcprov-jdk18on/1.78, MIT AND CC0-1.0, approved, #14433
 maven/mavencentral/org.bouncycastle/bcprov-jdk18on/1.78.1, MIT AND CC0-1.0, approved, #14433
-maven/mavencentral/org.eclipse.angus/angus-activation/1.0.0, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.angus
-maven/mavencentral/org.eclipse.angus/angus-mail/1.0.0, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.angus
+maven/mavencentral/org.eclipse.angus/angus-activation/2.0.2, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.angus
+maven/mavencentral/org.eclipse.angus/angus-mail/2.0.3, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.angus
 maven/mavencentral/org.eclipse.edc/api-configuration/0.8.1, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/boot-spi/0.8.1, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/core-spi/0.8.1, Apache-2.0, approved, technology.edc
@@ -146,15 +119,14 @@ maven/mavencentral/org.eclipse.edc/verifiable-credentials-spi/0.8.1, Apache-2.0,
 maven/mavencentral/org.eclipse.edc/web-spi/0.8.1, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.jetty.toolchain/jetty-jakarta-servlet-api/5.0.2, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.eclipse.parsson/parsson/1.1.6, EPL-2.0, approved, ee4j.parsson
-maven/mavencentral/org.glassfish.jaxb/codemodel/4.0.3, BSD-3-Clause, approved, ee4j.jaxb-impl
-maven/mavencentral/org.glassfish.jaxb/jaxb-core/4.0.3, BSD-3-Clause, approved, ee4j.jaxb-impl
-maven/mavencentral/org.glassfish.jaxb/jaxb-jxc/4.0.3, BSD-3-Clause, approved, ee4j.jaxb-impl
-maven/mavencentral/org.glassfish.jaxb/jaxb-runtime/4.0.3, BSD-3-Clause, approved, ee4j.jaxb-impl
-maven/mavencentral/org.glassfish.jaxb/jaxb-xjc/4.0.3, BSD-3-Clause, approved, ee4j.jaxb-impl
-maven/mavencentral/org.glassfish.jaxb/txw2/4.0.3, BSD-3-Clause, approved, ee4j.jaxb-impl
-maven/mavencentral/org.glassfish.jaxb/xsom/4.0.3, BSD-3-Clause, approved, ee4j.jaxb-impl
+maven/mavencentral/org.glassfish.jaxb/codemodel/4.0.5, BSD-3-Clause, approved, ee4j.jaxb-impl
+maven/mavencentral/org.glassfish.jaxb/jaxb-core/4.0.5, BSD-3-Clause, approved, ee4j.jaxb-impl
+maven/mavencentral/org.glassfish.jaxb/jaxb-jxc/4.0.5, BSD-3-Clause, approved, ee4j.jaxb-impl
+maven/mavencentral/org.glassfish.jaxb/jaxb-runtime/4.0.5, BSD-3-Clause, approved, ee4j.jaxb-impl
+maven/mavencentral/org.glassfish.jaxb/jaxb-xjc/4.0.5, BSD-3-Clause, approved, ee4j.jaxb-impl
+maven/mavencentral/org.glassfish.jaxb/txw2/4.0.5, BSD-3-Clause, approved, ee4j.jaxb-impl
+maven/mavencentral/org.glassfish.jaxb/xsom/4.0.5, BSD-3-Clause, approved, ee4j.jaxb-impl
 maven/mavencentral/org.glassfish/jakarta.json/2.0.1, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jsonp
-maven/mavencentral/org.hamcrest/hamcrest/2.1, BSD-3-Clause, approved, clearlydefined
 maven/mavencentral/org.hamcrest/hamcrest/2.2, BSD-3-Clause, approved, #17677
 maven/mavencentral/org.hdrhistogram/HdrHistogram/2.2.2, BSD-2-Clause AND CC0-1.0 AND CC0-1.0, approved, #14828
 maven/mavencentral/org.jacoco/org.jacoco.agent/0.8.11, EPL-2.0, approved, CQ23285
@@ -172,7 +144,6 @@ maven/mavencentral/org.jboss.resteasy/resteasy-jaxb-provider/6.2.7.Final, Apache
 maven/mavencentral/org.jboss.resteasy/resteasy-multipart-provider/6.2.7.Final, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.jboss/jandex/2.4.4.Final, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.jetbrains/annotations/24.1.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.junit.jupiter/junit-jupiter-api/5.10.2, EPL-2.0, approved, #9714
 maven/mavencentral/org.junit.jupiter/junit-jupiter-api/5.10.3, EPL-2.0, approved, #9714
 maven/mavencentral/org.junit.jupiter/junit-jupiter-engine/5.10.3, EPL-2.0, approved, #9711
 maven/mavencentral/org.junit.jupiter/junit-jupiter-params/5.10.3, EPL-2.0, approved, #15250
@@ -187,31 +158,29 @@ maven/mavencentral/org.keycloak/keycloak-core/25.0.2, Apache-2.0, approved, clea
 maven/mavencentral/org.latencyutils/LatencyUtils/2.0.3, CC0-1.0, approved, #15280
 maven/mavencentral/org.mockito/mockito-core/5.11.0, MIT AND (Apache-2.0 AND MIT) AND Apache-2.0, approved, #13505
 maven/mavencentral/org.mockito/mockito-junit-jupiter/5.11.0, MIT, approved, #13504
-maven/mavencentral/org.objenesis/objenesis/3.3, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.objenesis/objenesis/3.3, Apache-2.0, approved, #19727
 maven/mavencentral/org.opentest4j/opentest4j/1.3.0, Apache-2.0, approved, #9713
 maven/mavencentral/org.ow2.asm/asm-commons/9.6, BSD-3-Clause, approved, #10775
 maven/mavencentral/org.ow2.asm/asm-tree/9.6, BSD-3-Clause, approved, #10773
 maven/mavencentral/org.ow2.asm/asm/9.6, BSD-3-Clause, approved, #10776
+maven/mavencentral/org.projectlombok/lombok/1.18.34, MIT, approved, #15192
 maven/mavencentral/org.reactivestreams/reactive-streams/1.0.4, CC0-1.0, approved, CQ16332
 maven/mavencentral/org.skyscreamer/jsonassert/1.5.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.slf4j/jul-to-slf4j/2.0.13, MIT, approved, #7698
-maven/mavencentral/org.slf4j/slf4j-api/1.7.26, MIT, approved, CQ13368
-maven/mavencentral/org.slf4j/slf4j-api/1.7.36, MIT, approved, CQ13368
-maven/mavencentral/org.slf4j/slf4j-api/2.0.11, MIT, approved, #5915
 maven/mavencentral/org.slf4j/slf4j-api/2.0.13, MIT, approved, #5915
-maven/mavencentral/org.slf4j/slf4j-api/2.0.9, MIT, approved, #5915
 maven/mavencentral/org.springdoc/springdoc-openapi-starter-common/2.4.0, Apache-2.0, approved, #13755
 maven/mavencentral/org.springdoc/springdoc-openapi-starter-webmvc-api/2.4.0, Apache-2.0, approved, #13748
 maven/mavencentral/org.springdoc/springdoc-openapi-starter-webmvc-ui/2.4.0, Apache-2.0, approved, #13754
 maven/mavencentral/org.springframework.boot/spring-boot-actuator-autoconfigure/3.3.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.springframework.boot/spring-boot-actuator/3.3.2, Apache-2.0, approved, #16976
-maven/mavencentral/org.springframework.boot/spring-boot-autoconfigure/3.2.3, Apache-2.0, approved, #11751
-maven/mavencentral/org.springframework.boot/spring-boot-autoconfigure/3.2.7, Apache-2.0, approved, #11751
 maven/mavencentral/org.springframework.boot/spring-boot-autoconfigure/3.3.2, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.springframework.boot/spring-boot-devtools/3.3.2, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.springframework.boot/spring-boot-starter-actuator/3.3.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.springframework.boot/spring-boot-starter-json/3.3.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.springframework.boot/spring-boot-starter-logging/3.3.2, Apache-2.0, approved, #16886
+maven/mavencentral/org.springframework.boot/spring-boot-starter-test/3.3.2, Apache-2.0, approved, #16975
 maven/mavencentral/org.springframework.boot/spring-boot-starter-tomcat/3.3.2, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.springframework.boot/spring-boot-starter/3.2.7, Apache-2.0, approved, #11935
+maven/mavencentral/org.springframework.boot/spring-boot-starter-web/3.3.2, Apache-2.0, approved, #16893
 maven/mavencentral/org.springframework.boot/spring-boot-starter/3.3.2, Apache-2.0, approved, #16895
 maven/mavencentral/org.springframework.boot/spring-boot-test-autoconfigure/3.3.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.springframework.boot/spring-boot-test/3.3.2, Apache-2.0, approved, clearlydefined
@@ -221,7 +190,7 @@ maven/mavencentral/org.springframework.cloud/spring-cloud-context/4.1.4, Apache-
 maven/mavencentral/org.springframework.cloud/spring-cloud-openfeign-core/4.1.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.springframework.cloud/spring-cloud-starter-openfeign/4.1.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.springframework.cloud/spring-cloud-starter/4.1.4, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.springframework.security/spring-security-crypto/6.2.5, Apache-2.0 AND ISC, approved, #11908
+maven/mavencentral/org.springframework.security/spring-security-crypto/6.3.1, Apache-2.0 AND ISC, approved, #20893
 maven/mavencentral/org.springframework.security/spring-security-rsa/1.1.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.springframework/spring-aop/6.1.11, Apache-2.0, approved, #15221
 maven/mavencentral/org.springframework/spring-beans/6.1.11, Apache-2.0, approved, #15213
@@ -230,11 +199,8 @@ maven/mavencentral/org.springframework/spring-core/6.1.11, Apache-2.0 AND BSD-3-
 maven/mavencentral/org.springframework/spring-expression/6.1.11, Apache-2.0, approved, #15264
 maven/mavencentral/org.springframework/spring-jcl/6.1.11, Apache-2.0, approved, #15266
 maven/mavencentral/org.springframework/spring-test/6.1.11, Apache-2.0, approved, #15265
-maven/mavencentral/org.springframework/spring-web/5.1.5.RELEASE, Apache-2.0 AND LicenseRef-Public-Domain, approved, CQ18367
-maven/mavencentral/org.springframework/spring-web/6.1.10, Apache-2.0, approved, #15188
 maven/mavencentral/org.springframework/spring-web/6.1.11, Apache-2.0, approved, #15188
 maven/mavencentral/org.springframework/spring-webmvc/6.1.11, Apache-2.0, approved, #15182
-maven/mavencentral/org.springframework/spring-webmvc/6.1.4, Apache-2.0, approved, #15182
 maven/mavencentral/org.webjars/swagger-ui/5.11.8, Apache-2.0, approved, #13756
 maven/mavencentral/org.xmlunit/xmlunit-core/2.9.1, Apache-2.0, approved, #6272
 maven/mavencentral/org.yaml/snakeyaml/2.2, Apache-2.0 AND (Apache-2.0 OR BSD-3-Clause OR EPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later), approved, #10232

--- a/charts/ssi-dim-wallet-stub/Chart.yaml
+++ b/charts/ssi-dim-wallet-stub/Chart.yaml
@@ -23,8 +23,8 @@ name: ssi-dim-wallet-stub
 description: |
   A Helm chart to deploy SSI DIM wallet stub in kubernetes cluster
 type: application
-version: 0.1.8
-appVersion: "0.0.5"
+version: 0.1.9
+appVersion: "0.0.6"
 home: https://github.com/eclipse-tractusx/ssi-dim-wallet-stub/tree/main/charts/ssi-dim-wallet-stub
 sources:
   - https://github.com/eclipse-tractusx/ssi-dim-wallet-stub/tree/main/charts/ssi-dim-wallet-stub

--- a/docs/architecture/main.md
+++ b/docs/architecture/main.md
@@ -85,7 +85,7 @@ interface or API documentation.
   minimum requirement to address is enabling the dependent microservices to deploy and pass the E2E tests. However, the
   business logic of multiple services outside of this scope might be too complex and error-prone for simulation. We have
   to define a minimum viable stub and continue delivering if there is any necessity or further requirement. Currently
-  only `type:MembershipCredential`, `type:BPNCredential` and `type:DataExchangeGovernanceCredential` are supported.
+  only `type:MembershipCredential`, `type:BPNCredential`, `UsagePurposeCredential` and `type:DataExchangeGovernanceCredential` are supported.
 
 * **Security:** Security features such as authentication, authorization, and data encryption must also be simulated with
   the stub service.

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@
 # ********************************************************************************/
 #
 group=org.eclipse.tractusx.wallet.stub
-version=0.0.1
+version=0.0.6
 springBootVersion=3.3.2
 springDependencyVersion=1.1.0
 openApiVersion=2.4.0

--- a/src/main/java/org/eclipse/tractusx/wallet/stub/apidoc/EDCStubApiDoc.java
+++ b/src/main/java/org/eclipse/tractusx/wallet/stub/apidoc/EDCStubApiDoc.java
@@ -66,7 +66,8 @@ public class EDCStubApiDoc {
                                     "credentialTypes":
                                     [
                                         "MembershipCredential",
-                                        "DataExchangeGovernanceCredential"
+                                        "DataExchangeGovernanceCredential",
+                                        "UsagePurposeCredential"
                                     ],
                                     "consumerDid": "did:web:c464-203-129-213-107.ngrok-free.app:BPNL000000000000",
                                     "providerDid": "did:web:c464-203-129-213-107.ngrok-free.app:BPNL000000000000"
@@ -145,7 +146,23 @@ public class EDCStubApiDoc {
                                  ],
                                  "@type": "PresentationQueryMessage"
                              }
-                            """, description = "Create VP access token for Membership Credential and DataExchange Governance Credential", name = "Create VP access token for Membership Credential and DataExchange Governance Credential")
+                            """, description = "Create VP access token for Membership Credential and DataExchange Governance Credential", name = "Create VP access token for Membership Credential and DataExchange Governance Credential"),
+                    @ExampleObject(value = """
+                            {
+                                 "scope":
+                                 [
+                                     "org.eclipse.tractusx.vc.type:MembershipCredential:read",
+                                     "org.eclipse.tractusx.vc.type:DataExchangeGovernanceCredential:read",
+                                     "org.eclipse.tractusx.vc.type:UsagePurposeCredential:read"
+                                 ],
+                                 "@context":
+                                 [
+                                     "https://identity.foundation/presentation-exchange/submission/v1",
+                                     "https://w3id.org/tractusx-trust/v0.8"
+                                 ],
+                                 "@type": "PresentationQueryMessage"
+                             }
+                            """, description = "Create VP access token for Membership Credential, UsagePurposeCredential and DataExchange Governance Credential", name = "Create VP access token for Membership Credential, UsagePurposeCredential and DataExchange Governance Credential")
 
             })
     })

--- a/src/main/java/org/eclipse/tractusx/wallet/stub/credential/CredentialService.java
+++ b/src/main/java/org/eclipse/tractusx/wallet/stub/credential/CredentialService.java
@@ -138,6 +138,8 @@ public class CredentialService {
                 return issueBpnCredential(holderBpn, issuerDocument, holderDocument, vcIdUri, vcId);
             } else if (type.equals(StringPool.DATA_EXCHANGE_CREDENTIAL)) {
                 return issueDataExchangeGovernanceCredential(holderBpn, issuerDocument, holderDocument, vcIdUri, vcId);
+            } else if (type.equals(StringPool.USAGE_PURPOSE_CREDENTIAL)) {
+                return issueUsagePurposeCredential(holderBpn, issuerDocument, holderDocument, vcIdUri, vcId);
             } else {
                 throw new IllegalArgumentException("vc type -> " + type + " is not supported");
             }
@@ -191,6 +193,22 @@ public class CredentialService {
                 vcIdUri.toString(), StringPool.BPN_CREDENTIAL, DateUtils.addYears(new Date(), 1), subject);
 
         memoryStorage.saveCredentials(vcId, credentialWithoutProof, holderBpn, StringPool.BPN_CREDENTIAL);
+        return credentialWithoutProof;
+    }
+
+    private CustomCredential issueUsagePurposeCredential(String holderBpn, DidDocument issuerDocument, DidDocument holderDocument, URI vcIdUri, String vcId) {
+        Map<String, Object> subject = new HashMap<>();
+        subject.put(StringPool.ID, holderDocument.getId());
+        subject.put(StringPool.HOLDER_IDENTIFIER, holderBpn);
+        // here does this specification for group and UC come from?
+        // subject.put(StringPool.GROUP, "UseCaseFramework");
+        // subject.put(StringPool.USE_CASE, "DataExchangeGovernance");
+        // subject.put(StringPool.CONTRACT_TEMPLATE, "https://example.org/temp-1");
+        // subject.put(StringPool.CONTRACT_VERSION, "1.0");
+        CustomCredential credentialWithoutProof = CommonUtils.createCredential(issuerDocument.getId(),
+                vcIdUri.toString(), StringPool.USAGE_PURPOSE_CREDENTIAL, DateUtils.addYears(new Date(), 1), subject);
+
+        memoryStorage.saveCredentials(vcId, credentialWithoutProof, holderBpn, StringPool.USAGE_PURPOSE_CREDENTIAL);
         return credentialWithoutProof;
     }
 

--- a/src/main/java/org/eclipse/tractusx/wallet/stub/utils/StringPool.java
+++ b/src/main/java/org/eclipse/tractusx/wallet/stub/utils/StringPool.java
@@ -40,6 +40,7 @@ public class StringPool {
     public static final String MEMBERSHIP_CREDENTIAL = "MembershipCredential";
     public static final String BPN_CREDENTIAL = "BpnCredential";
     public static final String DATA_EXCHANGE_CREDENTIAL = "DataExchangeGovernanceCredential";
+    public static final String USAGE_PURPOSE_CREDENTIAL = "UsagePurposeCredential";
     public static final String STATUS_LIST_2021_CREDENTIAL = "StatusList2021Credential";
     public static final String ENCODED_LIST = "encodedList";
     public static final String VERIFIABLE_CREDENTIAL_CAMEL_CASE = "verifiableCredential";


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of the changes introduced by this pull request. Explain the problem it 
solves or the feature it adds. -->

This PR adds the UsagePurposeCredential as it's missing. Had a session with @dvg36 and @saudkhan116 

Being honest, I'm not sure where the outcommented stuff for the new issuing method comes from. Feel free to point out existing specification or how to handle it.

I did not

- add a test, as there is none yet for CredentialService and it involved cryptography.
- update the DEPENDENCIES file as nothing has been updated


## Why

<!-- Why are these changes necessary? What problem does it solve? -->


## Issue Link

Refs: https://github.com/eclipse-tractusx/tractus-x-umbrella/issues/174


## Checklist
Please delete options that are not relevant.

- [x] I have followed the contributing guidelines

- [x] I have performed IP checks for added or updated 3rd party libraries

- [x] I have added copyright and license headers, footers (for .md files) or files (for images) //open source requirement

- [x] I have performed a self-review of my own code

- [x] I have successfully tested my changes locally

- [ ] I have added tests and updated existing tests that prove my changes work

- [x] I have checked that new and existing tests pass locally with my changes

- [x] I have commented my code, particularly in hard-to-understand areas