### PR TITLE
fix: add missing Bitnami repository to Helm dependencies

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -51,6 +51,7 @@ jobs:
       - name: Update helm SSI-DIM-WALLET-STUB-DATABASE dependencies
         run: |
           cd charts/ssi-dim-wallet-stub
+          helm repo add bitnami https://charts.bitnami.com/bitnami
           helm repo add tractusx-dev https://eclipse-tractusx.github.io/charts/dev
           helm dependency update
 


### PR DESCRIPTION
## Description

This pull request adds the missing Bitnami Helm repository definition required for packaging the ssi-dim-wallet-stub chart. Without this, the Helm chart releaser fails during CI due to an unresolved dependency.

## Why

The CI pipeline fails when attempting to release Helm charts because the Bitnami repository is not defined, resulting in the error:
`Error: no repository definition for https://charts.bitnami.com/bitnami.`
Adding the missing dependency ensures the chart can be packaged and released successfully.
## Issue Link

Closes #58 

## Checklist

Please delete options that are not relevant.

- [X] I have followed the contributing guidelines

- [X] I have performed IP checks for added or updated 3rd party libraries

- [X] I have added copyright and license headers, footers (for .md files) or files (for images) //open source
  requirement

- [X] I have performed a self-review of my own code

- [X] I have successfully tested my changes locally

- [X] I have added tests and updated existing tests that prove my changes work

- [X] I have checked that new and existing tests pass locally with my changes

- [X] I have commented my code, particularly in hard-to-understand areas
