### PR TITLE
fix: increase probe seconds

### DIFF
--- a/charts/ssi-dim-wallet-stub-memory/Chart.yaml
+++ b/charts/ssi-dim-wallet-stub-memory/Chart.yaml
@@ -23,7 +23,7 @@ name: ssi-dim-wallet-stub-memory
 description: |
   A Helm chart to deploy SSI DIM wallet stub in kubernetes cluster
 type: application
-version: 0.1.10
+version: 0.1.11
 appVersion: "0.0.7"
 home: https://github.com/eclipse-tractusx/ssi-dim-wallet-stub/tree/main/charts/ssi-dim-wallet-stub
 sources:

--- a/charts/ssi-dim-wallet-stub-memory/values.yaml
+++ b/charts/ssi-dim-wallet-stub-memory/values.yaml
@@ -67,11 +67,11 @@ wallet:
     # -- When a probe fails, Kubernetes will try failureThreshold times before giving up. Giving up in case of liveness probe means restarting the container.
     failureThreshold: 3
     # -- Number of seconds after the container has started before readiness probes are initiated.
-    initialDelaySeconds: 20
+    initialDelaySeconds: 50
     # -- Number of seconds after which the probe times out.
-    timeoutSeconds: 15
+    timeoutSeconds: 60
     # -- How often (in seconds) to perform the probe
-    periodSeconds: 5
+    periodSeconds: 15
 
   # -- Kubernetes [readiness-probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)
   readinessProbe:
@@ -80,13 +80,13 @@ wallet:
     # -- When a probe fails, Kubernetes will try failureThreshold times before giving up. In case of readiness probe the Pod will be marked Unready.
     failureThreshold: 3
     # -- Number of seconds after the container has started before readiness probe are initiated.
-    initialDelaySeconds: 30
+    initialDelaySeconds: 50
     # -- How often (in seconds) to perform the probe
-    periodSeconds: 5
+    periodSeconds: 15
     # -- Minimum consecutive successes for the probe to be considered successful after having failed.
     successThreshold: 1
     # -- Number of seconds after which the probe times out.
-    timeoutSeconds: 5
+    timeoutSeconds: 60
 
   # -- ingress configuration
   ingress:

--- a/charts/ssi-dim-wallet-stub/Chart.yaml
+++ b/charts/ssi-dim-wallet-stub/Chart.yaml
@@ -24,7 +24,7 @@ name: ssi-dim-wallet-stub
 description: |
   A Helm chart to deploy SSI DIM wallet stub in kubernetes cluster
 type: application
-version: 0.1.10
+version: 0.1.11
 appVersion: "0.0.7"
 home: https://github.com/eclipse-tractusx/ssi-dim-wallet-stub/tree/main/charts/ssi-dim-wallet-stub
 sources:

--- a/charts/ssi-dim-wallet-stub/values.yaml
+++ b/charts/ssi-dim-wallet-stub/values.yaml
@@ -67,11 +67,11 @@ wallet:
     # -- When a probe fails, Kubernetes will try failureThreshold times before giving up. Giving up in case of liveness probe means restarting the container.
     failureThreshold: 3
     # -- Number of seconds after the container has started before readiness probes are initiated.
-    initialDelaySeconds: 20
+    initialDelaySeconds: 50
     # -- Number of seconds after which the probe times out.
-    timeoutSeconds: 15
+    timeoutSeconds: 60
     # -- How often (in seconds) to perform the probe
-    periodSeconds: 5
+    periodSeconds: 15
 
   # -- Kubernetes [readiness-probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)
   readinessProbe:
@@ -80,13 +80,13 @@ wallet:
     # -- When a probe fails, Kubernetes will try failureThreshold times before giving up. In case of readiness probe the Pod will be marked Unready.
     failureThreshold: 3
     # -- Number of seconds after the container has started before readiness probe are initiated.
-    initialDelaySeconds: 30
+    initialDelaySeconds: 50
     # -- How often (in seconds) to perform the probe
-    periodSeconds: 5
+    periodSeconds: 15
     # -- Minimum consecutive successes for the probe to be considered successful after having failed.
     successThreshold: 1
     # -- Number of seconds after which the probe times out.
-    timeoutSeconds: 5
+    timeoutSeconds: 60
 
   # -- ingress configuration
   ingress:


### PR DESCRIPTION
## Description

Increase liveness and readiness probe in order to make umbrella able to deploy it correctly.

## Why

At the moment, time is low and wallet is not able to deploy correctly in umbrella.

## Issue Link

Refs: [Umbrella#282](https://github.com/eclipse-tractusx/tractus-x-umbrella/issues/282)

## Checklist

Please delete options that are not relevant.

- [x] I have followed the contributing guidelines

- [x] I have performed IP checks for added or updated 3rd party libraries

- [x] I have added copyright and license headers, footers (for .md files) or files (for images) //open source
  requirement

- [x] I have performed a self-review of my own code

- [x] I have successfully tested my changes locally

- [x] I have added tests and updated existing tests that prove my changes work

- [x] I have checked that new and existing tests pass locally with my changes

- [x] I have commented my code, particularly in hard-to-understand areas
