### PR TITLE
Clarify function of keycloak.enabled flag in chart

### DIFF
--- a/charts/ssi-dim-wallet-stub-memory/README.md
+++ b/charts/ssi-dim-wallet-stub-memory/README.md
@@ -91,3 +91,4 @@ helm install wallet-stub -n wallet charts/ssi-dim-wallet-stub-memory
 | `wallet.service.type`                       | Kubernetes service type                                                                | `ClusterIP`                              |
 | `wallet.service.port`                       | Kubernetes service port                                                                | `8080`                                   |
 | `keycloak.enabled`                          | Enable Keycloak configuration                                                          | `false`                                  |
+| `keycloak.enabled`                            | Enable centralidp for testing                                                          | `false`                                           |

--- a/charts/ssi-dim-wallet-stub/README.md
+++ b/charts/ssi-dim-wallet-stub/README.md
@@ -95,7 +95,7 @@ helm install wallet-stub -n wallet charts/ssi-dim-wallet-stub
 | `wallet.postgresql.password`                  | The password to access the database                                                    | `postgrespassword`                                |
 | `wallet.service.type`                         | Kubernetes service type                                                                | `ClusterIP`                                       |
 | `wallet.service.port`                         | Kubernetes service port                                                                | `8080`                                            |
-| `keycloak.enabled`                            | Enable Keycloak configuration                                                          | `false`                                           |
+| `keycloak.enabled`                            | Enable centralidp for testing                                                          | `false`                                           |
 | `postgresql.fullnameOverride`                 | Overrides the default PostgreSQL release name with a custom name                       | `wallet-postgres`                                 |
 | `postgresql.enabled`                          | Enables the deployment of the PostgreSQL instance                                      | `true`                                            |
 | `postgresql.image.tag`                        | Specifies the PostgreSQL Docker image version to use                                   | `15-debian-11`                                    |


### PR DESCRIPTION
## Description

I changed the description for `keycloak.enabled` to be more descriptive about its function.

## Why

As a new person, attempting to configure the software, I found the existing documentation a bit confusing and lacking clarification about its purpose. The initial description stated that it enables just a keycloak configuration.

Having the values.yaml with:
```yaml
[...]
 keycloak:
    # -- Keycloak realm name
    realm: "CX-Central"
    # -- keycloak host
    authServerUrl: "http://localhost:28080/auth"
[...]
```

followed by 
```yaml
[...]
# -- Keycloak configuration
keycloak:
  enabled: false
```

makes it appear, that both are related to each other and **required**.
The description should empathize that it's for testing purposes.
A description marking it for **testing** purposes, should clarify that  when incorporating it into another chart,
it should be set to false.


## Issue Link

This PR is related to #69.

## Checklist

Please delete options that are not relevant.

- [x] I have followed the contributing guidelines

- [ ] I have performed IP checks for added or updated 3rd party libraries

- [ ] I have added copyright and license headers, footers (for .md files) or files (for images) //open source
  requirement

- [x] I have performed a self-review of my own code

- [x] I have successfully tested my changes locally

- [ ] I have added tests and updated existing tests that prove my changes work

- [ ] I have checked that new and existing tests pass locally with my changes

- [ ] I have commented my code, particularly in hard-to-understand areas
