### PR TITLE
chore: bump chart versions to 0.1.12 and update postgresql image configuration

### DIFF
--- a/charts/ssi-dim-wallet-stub-memory/Chart.yaml
+++ b/charts/ssi-dim-wallet-stub-memory/Chart.yaml
@@ -23,7 +23,7 @@ name: ssi-dim-wallet-stub-memory
 description: |
   A Helm chart to deploy SSI DIM wallet stub in kubernetes cluster
 type: application
-version: 0.1.11
+version: 0.1.12
 appVersion: "0.0.7"
 home: https://github.com/eclipse-tractusx/ssi-dim-wallet-stub/tree/main/charts/ssi-dim-wallet-stub
 sources:

--- a/charts/ssi-dim-wallet-stub/Chart.lock
+++ b/charts/ssi-dim-wallet-stub/Chart.lock
@@ -5,5 +5,5 @@ dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 12.12.10
-digest: sha256:a1bb81e1f2e1815a38d353a254962d58797ed910fba6734328e58870eb5c296f
-generated: "2025-02-27T14:47:11.273697182+01:00"
+digest: sha256:bb3919921638120aee12aa97b5026a0b3e6c1dbdeed83aac5f3e80734a123b02
+generated: "2025-09-26T15:24:32.867799088+02:00"

--- a/charts/ssi-dim-wallet-stub/Chart.yaml
+++ b/charts/ssi-dim-wallet-stub/Chart.yaml
@@ -24,7 +24,7 @@ name: ssi-dim-wallet-stub
 description: |
   A Helm chart to deploy SSI DIM wallet stub in kubernetes cluster
 type: application
-version: 0.1.11
+version: 0.1.12
 appVersion: "0.0.7"
 home: https://github.com/eclipse-tractusx/ssi-dim-wallet-stub/tree/main/charts/ssi-dim-wallet-stub
 sources:
@@ -36,5 +36,5 @@ dependencies:
     condition: keycloak.enabled
   - name: postgresql
     repository: https://charts.bitnami.com/bitnami
-    version: 12.x.x
+    version: 12.12.x
     condition: postgresql.enabled

--- a/charts/ssi-dim-wallet-stub/README.md
+++ b/charts/ssi-dim-wallet-stub/README.md
@@ -9,7 +9,7 @@
 | Repository                         | Name       | Version |
 |------------------------------------|------------|---------|
 | https://charts.bitnami.com/bitnami | keycloak   | 22.1.0  |
-| https://charts.bitnami.com/bitnami | postgresql | 16.4.8  |
+| https://charts.bitnami.com/bitnami | postgresql | 15.4.0  |
 
 ### Prerequisites
 

--- a/charts/ssi-dim-wallet-stub/values.yaml
+++ b/charts/ssi-dim-wallet-stub/values.yaml
@@ -162,7 +162,10 @@ postgresql:
   # -- Enable to deploy Postgresql
   enabled: true
   image:
-    tag: "15-debian-11"
+    # -- workaround to use bitnamilegacy chart for version 12.12.x till committers align on new postgresql charts
+    repository: bitnamilegacy/postgresql
+    # -- workaround to use bitnamilegacy chart for version 12.12.x till committers align on new postgresql charts
+    tag: 15.4.0-debian-11-r45
   configmap:
     name: wallet-postgres-configmap
   auth:


### PR DESCRIPTION
## Description

This PR updates the chart versions for several Helm charts and introduces a temporary workaround for PostgreSQL image configuration in the values.yaml

## Why

To ensure compatibility and deployment stability after the deprecation of the Bitnami Helm chart repository.

## Issue Link

Close #80 

## Checklist

Please delete options that are not relevant.

- [X] I have followed the contributing guidelines

- [X] I have performed IP checks for added or updated 3rd party libraries

- [X] I have added copyright and license headers, footers (for .md files) or files (for images) //open source
  requirement

- [X] I have performed a self-review of my own code

- [X] I have successfully tested my changes locally

- [X] I have added tests and updated existing tests that prove my changes work

- [X] I have checked that new and existing tests pass locally with my changes

- [X] I have commented my code, particularly in hard-to-understand areas
