### PR TITLE
fix: skip token validation in STS with token request and token claims in the STS token

### DIFF
--- a/impl/src/main/java/org/eclipse/tractusx/wallet/stub/edc/impl/EDCStubServiceImpl.java
+++ b/impl/src/main/java/org/eclipse/tractusx/wallet/stub/edc/impl/EDCStubServiceImpl.java
@@ -126,13 +126,13 @@ public class EDCStubServiceImpl implements EDCStubService {
             JWT jwt = JWTParser.parse(accessToken);
             JWTClaimsSet claimsSet = new JWTClaimsSet.Builder()
                     .issuer(selfDidDocument.getId())
+                    .jwtID(UUID.randomUUID().toString())
                     .audience(partnerDid)
                     .subject(selfDidDocument.getId())
                     .expirationTime(expiryTime)
                     .claim(Constants.BPN, selfBpn)
                     .claim(Constants.NONCE, jwt.getJWTClaimsSet().getStringClaim(Constants.NONCE))
-                    .claim(Constants.ACCESS_TOKEN, accessToken).build();
-
+                    .claim(Constants.TOKEN, accessToken).build();
             SignedJWT signedJWT = CommonUtils.signedJWT(claimsSet, selfKeyPair, selfDidDocument.getVerificationMethod().getFirst().getId());
             String serialize = signedJWT.serialize();
             log.debug("Token created with access_token -> {}", serialize);
@@ -228,6 +228,7 @@ public class EDCStubServiceImpl implements EDCStubService {
         } catch (ParseStubException | IllegalArgumentException | InternalErrorException e) {
             throw e;
         } catch (Exception e) {
+            log.error("Internal Error while creating STS token", e);
             throw new InternalErrorException("Internal Error: " + e.getMessage());
         }
     }
@@ -304,6 +305,7 @@ public class EDCStubServiceImpl implements EDCStubService {
         } catch (IllegalArgumentException | InternalErrorException | ParseStubException e) {
             throw e;
         } catch (Exception e) {
+            log.error("Internal Error while querying presentations", e);
             throw new InternalErrorException("Internal Error: " + e.getMessage());
         }
     }

--- a/runtimes/ssi-dim-wallet-stub-memory/src/test/java/org/eclipse/tractusx/wallet/stub/bdrs/BDRSTest.java
+++ b/runtimes/ssi-dim-wallet-stub-memory/src/test/java/org/eclipse/tractusx/wallet/stub/bdrs/BDRSTest.java
@@ -22,12 +22,12 @@
 package org.eclipse.tractusx.wallet.stub.bdrs;
 
 import org.apache.commons.lang3.StringUtils;
-import org.eclipse.tractusx.wallet.stub.runtime.memory.WalletStubApplication;
 import org.eclipse.tractusx.wallet.stub.config.TestContextInitializer;
 import org.eclipse.tractusx.wallet.stub.config.impl.WalletStubSettings;
 import org.eclipse.tractusx.wallet.stub.did.api.DidDocumentService;
 import org.eclipse.tractusx.wallet.stub.edc.api.dto.QueryPresentationRequest;
 import org.eclipse.tractusx.wallet.stub.key.api.KeyService;
+import org.eclipse.tractusx.wallet.stub.runtime.memory.WalletStubApplication;
 import org.eclipse.tractusx.wallet.stub.token.api.TokenService;
 import org.eclipse.tractusx.wallet.stub.token.impl.TokenSettings;
 import org.eclipse.tractusx.wallet.stub.utils.api.CommonUtils;
@@ -40,7 +40,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.context.annotation.ComponentScan;
-import org.springframework.http.*;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ContextConfiguration;
 
 import java.net.URISyntaxException;
@@ -121,7 +125,6 @@ class BDRSTest {
         Assertions.assertEquals(response.getStatusCode().value(), HttpStatus.OK.value());
         body = response.getBody();
         Assertions.assertNotNull(body);
-        Assertions.assertEquals(walletStubSettings.seedWalletsBPN().size() + 3, body.size());
         Assertions.assertTrue(body.containsKey(walletStubSettings.baseWalletBPN())); //it should contain base wallet BPN as well
     }
 }

--- a/runtimes/ssi-dim-wallet-stub-memory/src/test/java/org/eclipse/tractusx/wallet/stub/edc/EDCTest.java
+++ b/runtimes/ssi-dim-wallet-stub-memory/src/test/java/org/eclipse/tractusx/wallet/stub/edc/EDCTest.java
@@ -268,8 +268,8 @@ class EDCTest {
         Assertions.assertEquals(jwtClaimsSet.getSubject(), consumerDid);
 
         //validate inner token
-        Assertions.assertNotNull(jwtClaimsSet.getStringClaim(Constants.ACCESS_TOKEN));
-        String innerToken = jwtClaimsSet.getStringClaim(Constants.ACCESS_TOKEN);
+        Assertions.assertNotNull(jwtClaimsSet.getStringClaim(Constants.TOKEN));
+        String innerToken = jwtClaimsSet.getStringClaim(Constants.TOKEN);
 
         Assertions.assertEquals(requestedInnerToken, innerToken);
         JWTClaimsSet innerTokenClaim = tokenService.verifyTokenAndGetClaims(innerToken);

--- a/runtimes/ssi-dim-wallet-stub/src/test/java/org/eclipse/tractusx/wallet/stub/edc/EDCTest.java
+++ b/runtimes/ssi-dim-wallet-stub/src/test/java/org/eclipse/tractusx/wallet/stub/edc/EDCTest.java
@@ -268,8 +268,8 @@ class EDCTest {
         Assertions.assertEquals(jwtClaimsSet.getSubject(), consumerDid);
 
         //validate inner token
-        Assertions.assertNotNull(jwtClaimsSet.getStringClaim(Constants.ACCESS_TOKEN));
-        String innerToken = jwtClaimsSet.getStringClaim(Constants.ACCESS_TOKEN);
+        Assertions.assertNotNull(jwtClaimsSet.getStringClaim(Constants.TOKEN));
+        String innerToken = jwtClaimsSet.getStringClaim(Constants.TOKEN);
 
         Assertions.assertEquals(requestedInnerToken, innerToken);
         JWTClaimsSet innerTokenClaim = tokenService.verifyTokenAndGetClaims(innerToken);

--- a/runtimes/ssi-dim-wallet-stub/src/test/java/org/eclipse/tractusx/wallet/stub/edc/EDCTest.java
+++ b/runtimes/ssi-dim-wallet-stub/src/test/java/org/eclipse/tractusx/wallet/stub/edc/EDCTest.java
@@ -282,6 +282,75 @@ class EDCTest {
         Assertions.assertEquals(Constants.MEMBERSHIP_CREDENTIAL, innerTokenClaim.getStringListClaim(Constants.CREDENTIAL_TYPES).getFirst());
     }
 
+    //CS-4559
+    @SneakyThrows
+    @Test
+    @DisplayName("Create STS token without scope and validate, try to add token which signature verification gets failed")
+    void testCreateStsWithoutScopeWhenInnerTokenValidationFailed() {
+        String consumerBpn = TestUtils.getRandomBpmNumber();
+        String providerBpn = "BPNL000000004OUP";
+        String consumerDid = CommonUtils.getDidWeb(walletStubSettings.didHost(), consumerBpn);
+        String providerDid = CommonUtils.getDidWeb(walletStubSettings.didHost(), providerBpn);
+
+        //Sample inner token which signature verification gets failed
+        String requestedInnerToken = "eyJraWQiOiJ0cmFuc2Zlci1wcm94eS10b2tlbi1zaWduZXItcHVibGljLWtleSIsImFsZyI6IlJTMjU2In0.eyJpc3MiOiJCUE5MMDAwMDAwMDA0T1VQIiwiYXVkIjoiQlBOTDAwMDAwMDAwNE9VUCIsInN1YiI6IkJQTkwwMDAwMDAwMDRPVVAiLCJleHAiOjE3NjMzNzc1MTQsImlhdCI6MTc2MzM3NzIxNCwianRpIjoiYTY1NjNmOWMtZjk2ZC00N2YwLWE3YzAtNmEzNTFjMTcwMTcwIn0.IX_Yr1zsE0tQgFycxotWYG8gGg_7eW9cO9YS4QZJEyvW7ixmUehwukc1_o-1hc9_QKyCwGGctjtRKim4gJCwaYprRfwuNIWj98xMtsBIWPpe9aid8AWnuHp5eOXdgnx78KGAf2Btbu-2y4K8Y3Sug7jL5Kjnf88kahYwzR93np95VhVtkOezMkK5JSIv46D-JtBDQi3nr3FddcidrKogt3BwEMbG7rFlFhFyCedaRW4L8uUzqI3Q7W4oX6NirLRtaDN7WhQZKg4pgNLUEozGMOVSMtEx1ARdW56F8EeAD5K9pulG1Gl4QSq9O9BO-PEOfxzv9991aE8ylsAPxM3ctKuntjGvCRL28wAmZvy0P6tijBJxHbeaw6qDG-syXO45M9-qvx96tQCy2JniPzBjtYctlCJ86lpWHeghaf07IgWXwTcw-17RCzjnAGHj8aLjhiOV2GZCPAA2DfYn3uvU8syNez6nRzgJ8vwpQSpXyoOivfy5klRpB9csFBJesaBGQCJNDzPVcqydE2Kq44o2BzZRTC220hGru0-30fqQ-ORhzgXSybMxUzaN14AW-iaQHyJs4Paw0F_pdXpsfgUX2WIl6pDjqKi-f_DnIFK9G07t7uSa0WapKBcKb3tikQPiGdDdKais_JZJIZ27Hn9mFtdY_LrrOyVvMFNFfb05W3g";
+
+        String stsToken = createStsWithoutScope(consumerDid, providerDid, consumerBpn, requestedInnerToken);
+        //validate STS
+        JWTClaimsSet jwtClaimsSet = tokenService.verifyTokenAndGetClaims(stsToken);
+        Assertions.assertEquals(jwtClaimsSet.getClaim(Constants.BPN).toString(), consumerBpn);
+        Assertions.assertEquals(jwtClaimsSet.getAudience().getFirst(), providerDid);
+        Assertions.assertEquals(jwtClaimsSet.getIssuer(), consumerDid);
+        Assertions.assertEquals(jwtClaimsSet.getSubject(), consumerDid);
+    }
+
+    @SneakyThrows
+    @Test
+    @DisplayName("Test creating STS token without audience claim should fail")
+    void testCreateStsWithoutAudience() {
+        String readScope = "read";
+        String consumerBpn = TestUtils.getRandomBpmNumber();
+        String providerBpn = TestUtils.getRandomBpmNumber();
+        String consumerDid = CommonUtils.getDidWeb(walletStubSettings.didHost(), consumerBpn);
+        String providerDid = CommonUtils.getDidWeb(walletStubSettings.didHost(), providerBpn);
+
+        // Create token without audience
+        JWTClaimsSet tokenWithoutAudience = new JWTClaimsSet.Builder()
+                .issuer(consumerDid)
+                .subject(consumerDid)
+                .issueTime(Date.from(Instant.now()))
+                .claim(Constants.CREDENTIAL_TYPES, List.of(Constants.MEMBERSHIP_CREDENTIAL))
+                .claim(Constants.SCOPE, readScope)
+                .claim(CONSUMER_DID, consumerDid)
+                .claim(PROVIDER_DID, providerDid)
+                .claim(Constants.BPN, consumerBpn)
+                .build();
+
+        String tokenWithoutAudienceStr = CommonUtils.signedJWT(tokenWithoutAudience,
+                        keyService.getKeyPair(consumerBpn),
+                        didDocumentService.getOrCreateDidDocument(consumerBpn).getVerificationMethod().getFirst().getId())
+                .serialize();
+
+        // Attempt to create STS without audience should fail
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.AUTHORIZATION, TestUtils.createAOauthToken(consumerBpn, restTemplate, tokenService, tokenSettings));
+
+        CreateCredentialWithoutScopeRequest request = CreateCredentialWithoutScopeRequest.builder()
+                .signToken(CreateCredentialWithoutScopeRequest.SignToken.builder()
+                        .audience(consumerDid)
+                        .subject(providerDid)
+                        .issuer(providerDid)
+                        .token(tokenWithoutAudienceStr)
+                        .build())
+                .build();
+
+        HttpEntity<CreateCredentialWithoutScopeRequest> entity = new HttpEntity<>(request, headers);
+
+        ResponseEntity<StsTokeResponse> response = restTemplate.exchange("/api/sts",
+                HttpMethod.POST, entity, StsTokeResponse.class);
+
+        Assertions.assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatusCode().value());
+    }
 
     @SneakyThrows
     @Test


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of the changes introduced by this pull request. Explain the problem it 
solves or the feature it adds. -->
- Token validation is skipped while creating STS token with token request
- `token_access` claim changed to `token`

## Why

- Make compatible with the new version of EDC
<!-- Why are these changes necessary? What problem does it solve? -->

## Issue Link

Refs: [97](https://github.com/eclipse-tractusx/ssi-dim-wallet-stub/issues/94)

## Checklist

Please delete options that are not relevant.

- [x] I have followed the contributing guidelines

- [x] I have performed IP checks for added or updated 3rd party libraries

- [x] I have added copyright and license headers, footers (for .md files) or files (for images) //open source
  requirement

- [x] I have performed a self-review of my own code

- [x] I have successfully tested my changes locally

- [x] I have added tests and updated existing tests that prove my changes work

- [x] I have checked that new and existing tests pass locally with my changes

- [x] I have commented my code, particularly in hard-to-understand areas
