### PR TITLE
Bug: fix vp audience claim

### DIFF
--- a/charts/ssi-dim-wallet-stub/Chart.yaml
+++ b/charts/ssi-dim-wallet-stub/Chart.yaml
@@ -24,8 +24,8 @@ name: ssi-dim-wallet-stub
 description: |
   A Helm chart to deploy SSI DIM wallet stub in kubernetes cluster
 type: application
-version: 0.1.16
-appVersion: "0.0.10"
+version: 0.1.17
+appVersion: "0.0.11"
 home: https://github.com/eclipse-tractusx/ssi-dim-wallet-stub/tree/main/charts/ssi-dim-wallet-stub
 sources:
   - https://github.com/eclipse-tractusx/ssi-dim-wallet-stub/tree/main/charts/ssi-dim-wallet-stub

--- a/impl/src/main/java/org/eclipse/tractusx/wallet/stub/edc/impl/EDCStubServiceImpl.java
+++ b/impl/src/main/java/org/eclipse/tractusx/wallet/stub/edc/impl/EDCStubServiceImpl.java
@@ -238,7 +238,8 @@ public class EDCStubServiceImpl implements EDCStubService {
         try {
             log.debug("getting request for query credential with body-> {} token -> {}", objectMapper.writeValueAsString(request), StringEscapeUtils.escapeJava(token));
             JWTClaimsSet jwtClaimsSet = tokenService.verifyTokenAndGetClaims(token);
-            List<String> audience = jwtClaimsSet.getAudience();
+
+            List<String> audience = List.of(jwtClaimsSet.getIssuer());
 
             //to check token type and identify caller
             String innerAccessToken;

--- a/runtimes/ssi-dim-wallet-stub-memory/src/test/java/org/eclipse/tractusx/wallet/stub/edc/EDCTest.java
+++ b/runtimes/ssi-dim-wallet-stub-memory/src/test/java/org/eclipse/tractusx/wallet/stub/edc/EDCTest.java
@@ -214,7 +214,8 @@ class EDCTest {
         String vpToken = responseBody.getPresentation().getFirst();
         JWTClaimsSet jwtClaimsSet = tokenService.verifyTokenAndGetClaims(vpToken);
 
-        Assertions.assertTrue(jwtClaimsSet.getAudience().contains(providerDid));
+        // VP audience should be the issuer of the outer/wrapper token (the requesting party)
+        Assertions.assertTrue(jwtClaimsSet.getAudience().contains(consumerDid));
         Assertions.assertEquals(jwtClaimsSet.getSubject(), consumerDid);
         Assertions.assertEquals(jwtClaimsSet.getIssuer(), consumerDid);
 

--- a/runtimes/ssi-dim-wallet-stub/src/test/java/org/eclipse/tractusx/wallet/stub/edc/EDCTest.java
+++ b/runtimes/ssi-dim-wallet-stub/src/test/java/org/eclipse/tractusx/wallet/stub/edc/EDCTest.java
@@ -134,7 +134,8 @@ class EDCTest {
         String vpToken = responseBody.getPresentation().getFirst();
         JWTClaimsSet jwtClaimsSet = tokenService.verifyTokenAndGetClaims(vpToken);
 
-        Assertions.assertTrue(jwtClaimsSet.getAudience().contains(providerDid));
+        // VP audience should be the issuer of the outer/wrapper token (the requesting party)
+        Assertions.assertTrue(jwtClaimsSet.getAudience().contains(consumerDid));
         Assertions.assertEquals(jwtClaimsSet.getSubject(), consumerDid);
         Assertions.assertEquals(jwtClaimsSet.getIssuer(), consumerDid);
 
@@ -214,7 +215,8 @@ class EDCTest {
         String vpToken = responseBody.getPresentation().getFirst();
         JWTClaimsSet jwtClaimsSet = tokenService.verifyTokenAndGetClaims(vpToken);
 
-        Assertions.assertTrue(jwtClaimsSet.getAudience().contains(providerDid));
+        // VP audience should be the issuer of the outer/wrapper token (the requesting party)
+        Assertions.assertTrue(jwtClaimsSet.getAudience().contains(consumerDid));
         Assertions.assertEquals(jwtClaimsSet.getSubject(), consumerDid);
         Assertions.assertEquals(jwtClaimsSet.getIssuer(), consumerDid);
 


### PR DESCRIPTION
---

## Description

In `queryPresentations()`, the VP audience claim was set using `jwtClaimsSet.getAudience()` (the credential holder's DID) instead of `jwtClaimsSet.getIssuer()` (the requesting party's DID). This caused EDC connectors to reject the VP with `Token audience claim did not contain expected audience` during IATP catalog requests.

## Why

The provider EDC validates that the received VP has `aud = its own DID`. The outer STS token has `iss=providerDID, aud=consumerDID`, so using the audience produced `aud=consumerDID` in the VP, which the provider rejected with a 401 Unauthorized.

## Issue Link

Refs: N/A (discovered during Tractus-X umbrella data-exchange testing)

## Checklist

- [x] I have followed the contributing guidelines
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests and updated existing tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas