### PR TITLE
chore(migrate-action-version): migrate checkout version

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -56,7 +56,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL


### PR DESCRIPTION
## Description

This PR "migrates" the used version (without any upgrade) for checkout action to SHA. NO upgrade is done.
The SHA values can be found [here](https://github.com/actions/checkout/releases)

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files