### PR TITLE
fix: use nindent for ingress annotations rendering

### DIFF
--- a/charts/ssi-dim-wallet-stub-memory/Chart.yaml
+++ b/charts/ssi-dim-wallet-stub-memory/Chart.yaml
@@ -23,7 +23,7 @@ name: ssi-dim-wallet-stub-memory
 description: |
   A Helm chart to deploy SSI DIM wallet stub in kubernetes cluster
 type: application
-version: 0.1.17
+version: 0.1.18
 appVersion: "0.0.11"
 home: https://github.com/eclipse-tractusx/ssi-dim-wallet-stub/tree/main/charts/ssi-dim-wallet-stub
 sources:

--- a/charts/ssi-dim-wallet-stub-memory/templates/ingress.yaml
+++ b/charts/ssi-dim-wallet-stub-memory/templates/ingress.yaml
@@ -25,7 +25,7 @@ metadata:
   name: {{.Values.wallet.ingressName}}
   namespace: {{.Values.wallet.nameSpace}}
   annotations:
-  {{.Values.wallet.ingress.annotations | toYaml | indent 4}}
+    {{- .Values.wallet.ingress.annotations | toYaml | nindent 4 }}
 spec:
   ingressClassName: {{.Values.wallet.ingress.className}}
   {{- if .Values.wallet.ingress.tls.enabled}}

--- a/charts/ssi-dim-wallet-stub/Chart.yaml
+++ b/charts/ssi-dim-wallet-stub/Chart.yaml
@@ -24,7 +24,7 @@ name: ssi-dim-wallet-stub
 description: |
   A Helm chart to deploy SSI DIM wallet stub in kubernetes cluster
 type: application
-version: 0.1.17
+version: 0.1.18
 appVersion: "0.0.11"
 home: https://github.com/eclipse-tractusx/ssi-dim-wallet-stub/tree/main/charts/ssi-dim-wallet-stub
 sources:

--- a/charts/ssi-dim-wallet-stub/templates/ingress.yaml
+++ b/charts/ssi-dim-wallet-stub/templates/ingress.yaml
@@ -25,7 +25,7 @@ metadata:
   name: {{.Values.wallet.ingressName}}
   namespace: {{.Values.wallet.nameSpace}}
   annotations:
-  {{.Values.wallet.ingress.annotations | toYaml | indent 4}}
+    {{- .Values.wallet.ingress.annotations | toYaml | nindent 4 }}
 spec:
   ingressClassName: {{.Values.wallet.ingress.className}}
   {{- if .Values.wallet.ingress.tls.enabled}}


### PR DESCRIPTION
  ## Description
  The ingress templates in `ssi-dim-wallet-stub` and `ssi-dim-wallet-stub-memory` used `indent` when rendering `wallet.ingress.annotations` via `toYaml`. With a single annotation this worked, but with two or more annotations Helm produced invalid YAML (only the first line was indented correctly).
  
  This change replaces `indent` with `nindent` and trims whitespace so multiple annotations render correctly under the `annotations:` block. Chart versions are bumped to `0.1.18` for both charts.
  
  ## Why
  When installing via the umbrella Helm chart with multiple ingress annotations (e.g. rewrite-target, use-regex, enable-cors, cors-allow-origin), `helm template` / `helm install` failed with a YAML parse error. This blocked deployments that need more than one ingress annotation on the wallet stub.
  
  ## Issue Link
  Fixes #92
  
  ## Checklist
  Please delete options that are not relevant.
  - [x] I have followed the contributing guidelines
  - [ ] I have performed IP checks for added or updated 3rd party libraries
  - [ ] I have added copyright and license headers, footers (for .md files) or files (for images) //open source requirement
  - [x] I have performed a self-review of my own code
  - [x] I have successfully tested my changes locally
  - [ ] I have added tests and updated existing tests that prove my changes work
  - [ ] I have checked that new and existing tests pass locally with my changes
  - [ ] I have commented my code, particularly in hard-to-understand areas