### PR TITLE
chore: pin GitHub Actions workflows to immutable SHA digests

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -56,11 +56,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2.28.1
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file
@@ -75,7 +75,7 @@ jobs:
       # Automates dependency installation for Python, Ruby, and JavaScript, optimizing the CodeQL analysis setup
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2.28.1
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -87,7 +87,7 @@ jobs:
       #     ./location_of_script_within_repo/buildscript.sh
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.25.10
         with:
           category: "/language:${{matrix.language}}"
           fail-on: error

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           fetch-depth: 0
 
@@ -44,7 +44,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -92,7 +92,7 @@ jobs:
           helm dependency update
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.7.0
+        uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
         with:
           # Tell cr to skip dependency update because we just did it
           skip_existing: true

--- a/.github/workflows/kics.yaml
+++ b/.github/workflows/kics.yaml
@@ -42,10 +42,10 @@ jobs:
       security-events: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: KICS scan
-        uses: checkmarx/kics-github-action@master
+        uses: checkmarx/kics-github-action@05aa5eb70eede1355220f4ca5238d96b397e30a6 # v2.1.20
         with:
           # Scanning directory .
           path: "."
@@ -67,6 +67,6 @@ jobs:
       # Upload findings to GitHub Advanced Security Dashboard
       - name: Upload SARIF file for GitHub Advanced Security Dashboard
         if: always()
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2.28.1
         with:
           sarif_file: kicsResults/results.sarif

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           fetch-depth: 0  # Ensure full clone for pull request workflows
 

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -44,7 +44,7 @@ jobs:
   verify-license-headers:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.5.2
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - name: "Check for files without a license header"
         run: |-
           # checks all java, yaml, kts and sql files for an Apache 2.0 license header
@@ -60,9 +60,9 @@ jobs:
     continue-on-error: false
     if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: 'Check Allowed Licenses'
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
         with:
           fail-on-severity: critical
           # Representation of this list: https://www.eclipse.org/legal/licenses.php#
@@ -79,8 +79,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
     steps:
-      - uses: actions/checkout@v4
-      - uses: eclipse-edc/.github/.github/actions/setup-build@main
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: eclipse-edc/.github/.github/actions/setup-build@5a53f5fc4f8bf4e134a590a0fc6f8c746f8ae366 # main
       - name: Download latest Eclipse Dash
         run: |
           curl -L https://repo.eclipse.org/service/local/artifact/maven/redirect\?r\=dash-licenses\&g\=org.eclipse.dash\&a\=org.eclipse.dash.licenses\&v\=LATEST --output dash.jar
@@ -123,7 +123,7 @@ jobs:
     runs-on: ubuntu-latest
     #needs: [ Review-Allowed-Licenses, Dash-Verify-Licenses ] # We need to fix this workflow or we can utilize gradle task to check license
     steps:
-      - uses: actions/checkout@v3.5.2
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - uses: ./.github/actions/setup-java
       - name: Run Unit tests and sonar scan
         env:


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
This PR replaces all mutable GitHub Actions version references (e.g. `@master`, `@main`, and floating tags like `@v3` and `@v4`) in `.github/workflows/` with **immutable, SHA-pinned** references. This is a supply-chain security hardening measure.

### :warning: Why this matters
Using mutable version tags means your CI/CD pipeline silently executes **whatever code an action's maintainer - or an attacker who has compromised their account - pushes** to that branch or tag at any point in time. Pinning to a full 40-character commit SHA provides immutability and auditability.

### Changes introduced in this PR
The following action references in this repository have been replaced. A human-readable version comment is retained next to each SHA for maintainability.

| Workflow File | Old Reference | New SHA-Pinned Reference | Resolved Version |
| --- | --- | --- | --- |
| `.github/workflows/kics.yaml` | `checkmarx/kics-github-action@master` | `checkmarx/kics-github-action@05aa5eb70eede1355220f4ca5238d96b397e30a6` | v2.1.20 |
| `.github/workflows/verify.yaml` | `eclipse-edc/.github/.github/actions/setup-build@main` | `eclipse-edc/.github/.github/actions/setup-build@5a53f5fc4f8bf4e134a590a0fc6f8c746f8ae366` | main |
| `.github/workflows/verify.yaml` | `actions/dependency-review-action@v4` | `actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48` | v4.9.0 |
| `.github/workflows/codeql.yaml` | `github/codeql-action/*@v2/v3` | `github/codeql-action/*@SHA` | v2.28.1 / v3.25.10 |
| Multiple | `actions/checkout@v3/v4` | `actions/checkout@SHA` | v3.6.0 / v4.1.7 |
| `.github/workflows/helm-release.yml` | `azure/setup-helm@v3` | `azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78` | v3.5 |
| `.github/workflows/helm-release.yml` | `helm/chart-releaser-action@v1.7.0` | `helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f` | v1.7.0 |

## Pre-review checks
- [ ] DEPENDENCIES are up-to-date.
- [x] Copyright and license header are present on all affected files