### PR TITLE
Gateway capability added

### DIFF
--- a/charts/ssi-dim-wallet-stub-memory/Chart.yaml
+++ b/charts/ssi-dim-wallet-stub-memory/Chart.yaml
@@ -23,7 +23,7 @@ name: ssi-dim-wallet-stub-memory
 description: |
   A Helm chart to deploy SSI DIM wallet stub in kubernetes cluster
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: "0.1.0"
 home: https://github.com/eclipse-tractusx/ssi-dim-wallet-stub/tree/main/charts/ssi-dim-wallet-stub
 sources:

--- a/charts/ssi-dim-wallet-stub-memory/templates/httproute.yaml
+++ b/charts/ssi-dim-wallet-stub-memory/templates/httproute.yaml
@@ -1,0 +1,63 @@
+{{- if .Values.wallet.httpRoute.enabled}}
+
+###############################################################
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+###############################################################
+
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{.Values.wallet.ingressName}}
+  namespace: {{.Values.wallet.nameSpace}}
+  {{- with .Values.wallet.httpRoute.annotations}}
+  annotations:
+    {{- toYaml . | nindent 4}}
+  {{- end}}
+spec:
+  {{- with .Values.wallet.httpRoute.parentRefs}}
+  parentRefs:
+    {{- toYaml . | nindent 4}}
+  {{- end}}
+  {{- with .Values.wallet.host}}
+  hostnames:
+    - {{.}}
+  {{- end}}
+  rules:
+    {{- if .Values.wallet.httpRoute.rules}}
+    {{- range .Values.wallet.httpRoute.rules}}
+    - {{- with .matches}}
+      matches:
+      {{- toYaml . | nindent 8}}
+      {{- end}}
+      {{- with .filters}}
+      filters:
+      {{- toYaml . | nindent 8}}
+      {{- end}}
+      backendRefs:
+        - name: {{$.Values.wallet.serviceName}}
+          port: {{$.Values.wallet.service.port}}
+          weight: 1
+    {{- end}}
+    {{- else}}
+    # Catch-all rule: route all traffic to the backend service
+    - backendRefs:
+        - name: {{$.Values.wallet.serviceName}}
+          port: {{$.Values.wallet.service.port}}
+          weight: 1
+    {{- end}}
+{{- end}}

--- a/charts/ssi-dim-wallet-stub-memory/values.yaml
+++ b/charts/ssi-dim-wallet-stub-memory/values.yaml
@@ -98,6 +98,25 @@ wallet:
     urlPrefix: /
     className: nginx
     annotations: { }
+  # -- Gateway API HTTPRoute configuration
+  # TLS is handled at the Gateway level, not here.
+  httpRoute:
+    enabled: false
+    annotations: { }
+    # -- Which Gateways this Route attaches to.
+    parentRefs: []
+    #   - name: gateway
+    #     namespace: traefik
+    #     sectionName: http
+    #   - name: gateway
+    #     namespace: traefik
+    #     sectionName: https
+    # -- Routing rules. If empty, a catch-all rule is generated automatically.
+    rules: []
+    #   - matches:
+    #     - path:
+    #         type: PathPrefix
+    #         value: /api
   swagger:
     ui:
       # -- enable swagger API doc UI

--- a/charts/ssi-dim-wallet-stub/Chart.yaml
+++ b/charts/ssi-dim-wallet-stub/Chart.yaml
@@ -24,7 +24,7 @@ name: ssi-dim-wallet-stub
 description: |
   A Helm chart to deploy SSI DIM wallet stub in kubernetes cluster
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: "0.1.0"
 home: https://github.com/eclipse-tractusx/ssi-dim-wallet-stub/tree/main/charts/ssi-dim-wallet-stub
 sources:

--- a/charts/ssi-dim-wallet-stub/templates/httproute.yaml
+++ b/charts/ssi-dim-wallet-stub/templates/httproute.yaml
@@ -1,0 +1,63 @@
+{{- if .Values.wallet.httpRoute.enabled}}
+
+###############################################################
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+###############################################################
+
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{.Values.wallet.ingressName}}
+  namespace: {{.Values.wallet.nameSpace}}
+  {{- with .Values.wallet.httpRoute.annotations}}
+  annotations:
+    {{- toYaml . | nindent 4}}
+  {{- end}}
+spec:
+  {{- with .Values.wallet.httpRoute.parentRefs}}
+  parentRefs:
+    {{- toYaml . | nindent 4}}
+  {{- end}}
+  {{- with .Values.wallet.host}}
+  hostnames:
+    - {{.}}
+  {{- end}}
+  rules:
+    {{- if .Values.wallet.httpRoute.rules}}
+    {{- range .Values.wallet.httpRoute.rules}}
+    - {{- with .matches}}
+      matches:
+      {{- toYaml . | nindent 8}}
+      {{- end}}
+      {{- with .filters}}
+      filters:
+      {{- toYaml . | nindent 8}}
+      {{- end}}
+      backendRefs:
+        - name: {{$.Values.wallet.serviceName}}
+          port: {{$.Values.wallet.service.port}}
+          weight: 1
+    {{- end}}
+    {{- else}}
+    # Catch-all rule: route all traffic to the backend service
+    - backendRefs:
+        - name: {{$.Values.wallet.serviceName}}
+          port: {{$.Values.wallet.service.port}}
+          weight: 1
+    {{- end}}
+{{- end}}

--- a/charts/ssi-dim-wallet-stub/values.yaml
+++ b/charts/ssi-dim-wallet-stub/values.yaml
@@ -98,6 +98,25 @@ wallet:
     urlPrefix: /
     className: nginx
     annotations: { }
+  # -- Gateway API HTTPRoute configuration
+  # TLS is handled at the Gateway level, not here.
+  httpRoute:
+    enabled: false
+    annotations: { }
+    # -- Which Gateways this Route attaches to.
+    parentRefs: []
+    #   - name: gateway
+    #     namespace: traefik
+    #     sectionName: http
+    #   - name: gateway
+    #     namespace: traefik
+    #     sectionName: https
+    # -- Routing rules. If empty, a catch-all rule is generated automatically.
+    rules: []
+    #   - matches:
+    #     - path:
+    #         type: PathPrefix
+    #         value: /api
   swagger:
     ui:
       # -- enable swagger API doc UI


### PR DESCRIPTION
## Description

Implementation of Gateway API usage,

## Why

Ingress-Nginx is not maintained anymore. 
Gateway API introduces the flexibility of user's choice of controller usage as well as being safe for future development in the Kubernetes Eco-system. 


## Issue Link

Fixes Refs: #112 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the contributing guidelines

- [x] I have **performed IP checks** for added or updated 3rd party libraries (_none_)

- [x] I have added copyright and license headers, footers (for .md files) or files (for images) //open source
  requirement
  `# Copyright (c) 2025 Contributors to the Eclipse Foundation`
  taken from the other template files

- [x] I have performed a self-review of my own code

- [x] I have successfully tested my changes locally
- Activating a configured ingress works (`wallet.endpoint.whatever.com`)
- Activating a configured httpRoute works (using a wildcard tls from the gateway `*.endpoint.whatever.com`)

Example configuration
```yaml
  # --- Gateway API HTTPRoute ---
  httpRoute:
    enabled: true
    annotations: { }
    parentRefs:
      - name: traefik-gateway
        namespace: traefik
        sectionName: web
      - name: traefik-https
        namespace: traefik
        sectionName: websecure
    rules: []
```

- [ ] I have added tests and updated existing tests that prove my changes work
* I tested ingress using traefik with tls
* I tested gateway using traefik as gateway controller with tls

I haven't tested both configurations without tls. 

- [ ] I have checked that new and existing tests pass locally with my changes

- [x] I have commented my code, particularly in hard-to-understand areas
